### PR TITLE
Updates to save matrices to sparse coo format with zarr v3

### DIFF
--- a/engine/README.md
+++ b/engine/README.md
@@ -1,8 +1,9 @@
 # DDR Engine
 
 This folder contains scripts and tools meant to format versions of the hydrofabric and create objects which help our routing. Examples include:
-- Mapping MERIT streamflow predictions to the hydrofabric
+- Mapping MERIT streamflow predictions to the hydrofabric catchments
 - Creaing adjacency matrices for implicit muskingum cunge routing 
+  - Matrices are saved in 
 
 How to run adjacency matrix:
 ```python 

--- a/engine/README.md
+++ b/engine/README.md
@@ -2,4 +2,9 @@
 
 This folder contains scripts and tools meant to format versions of the hydrofabric and create objects which help our routing. Examples include:
 - Mapping MERIT streamflow predictions to the hydrofabric
-- Creaing adjacency matrices for implicit muskingum cunge routing
+- Creaing adjacency matrices for implicit muskingum cunge routing 
+
+How to run adjacency matrix:
+```python 
+python engine/adjacency.py <path to hydrofabric gpkg> <store key> <store path>
+```

--- a/engine/adjacency.py
+++ b/engine/adjacency.py
@@ -103,6 +103,13 @@ indices_1[:] = coo.col
 values[:] = coo.data
 order[:] = zarr_order
 
+gauge_root.attrs["format"] = "COO"
+gauge_root.attrs["shape"] = list(coo.shape)
+gauge_root.attrs["data_types"] = {
+    "indices_0": coo.row.dtype.__str__(),
+    "indices_1": coo.col.dtype.__str__(),
+    "values": coo.data.dtype.__str__(),
+}
 print(f"Gauge {gauge} written to zarr")
 
 # Visual verification

--- a/engine/adjacency.py
+++ b/engine/adjacency.py
@@ -8,7 +8,7 @@
 @version 0.2
 
 An introduction script for building a lower triangular adjancency matrix
-from a NextGen hydrofabric and writing a sparse zarr store
+from a NextGen hydrofabric and writing a sparse zarr group
 """
 from pathlib import Path
 
@@ -74,9 +74,9 @@ for wb in ts_order:
 # Ensure, within tolerance, that this is a lower triangular matrix
 assert np.allclose(matrix, np.tril(matrix))
 
+# Comverting to a sparse COO matrix, and saving the output in many arrays within a zarr v3 group
 out_path = Path(out_path)
 store = zarr.storage.LocalStore(root=out_path)
-
 if out_path.exists():
     root = zarr.open_group(store=store) 
 else:
@@ -104,8 +104,6 @@ values[:] = coo.data
 order[:] = zarr_order
 
 print(f"Gauge {gauge} written to zarr")
-
-# np.save(out_path, matrix)
 
 # Visual verification
 # np.set_printoptions(threshold=np.inf, linewidth=np.inf)

--- a/src/ddr/dataset/train_dataset.py
+++ b/src/ddr/dataset/train_dataset.py
@@ -41,20 +41,13 @@ class train_dataset(torch.utils.data.Dataset):
         self.flowpath_attr = gpd.read_file(cfg.data_sources.local_hydrofabric, layer="flowpath-attributes-ml")
         self.flowpaths = gpd.read_file(cfg.data_sources.local_hydrofabric, layer="flowpaths")
         self.nexus = gpd.read_file(cfg.data_sources.local_hydrofabric, layer="nexus")
+
+        self.adjacency_matrix = np.load(cfg.data_sources.network)
         
         self.divides_sorted = self.divides.sort_values('tot_drainage_areasqkm')
         self.idx_mapper = {_id: idx for idx, _id in enumerate(self.divides_sorted["id"])}
         self.catchment_mapper = {_id : idx for idx, _id in enumerate(self.divides_sorted["divide_id"])}
-        self.network = np.zeros([len(self.idx_mapper), len(self.idx_mapper)])
         
-        # TODO create manual network connectivity matrix by drainage area
-        for idx, _id in enumerate(self.divides_sorted["id"]):
-            to_id = self.divides_sorted.iloc[idx]["toid"]
-            next_id = self.nexus[self.nexus["id"] == to_id]["toid"]
-            for __id in next_id:
-                col = idx
-                row = self.idx_mapper[__id]
-                self.network[row, col] = 1      
                 
         self.length = torch.tensor([self.flowpath_attr.iloc[self.idx_mapper[_id]]["Length_m"]] * 1000 for _id in self.flowpaths_sorted["id"])  
         self.slope = torch.tensor([self.flowpath_attr.iloc[self.idx_mapper[_id]]["So"]] for _id in self.flowpaths_sorted["id"])      


### PR DESCRIPTION
# Added:
- changed the matrix saving output to a sparse coo matrix format using zarr v3 arrays 
- created a `README.md` for some simple documentation

# Screenshots:
<img width="246" alt="image" src="https://github.com/user-attachments/assets/0c72daa0-287c-4086-8d31-b46956e97d38" />

In this example, `network.zarr/` is the local memory store, `network.zarr/01563500/` is the gauge we're saving, and `indices_0`, `indices_1`, `values` are the binsparse specified dimensions, with the following metadata:

```python
gauge_root.attrs["format"] = "COO"
gauge_root.attrs["shape"] = list(coo.shape)
gauge_root.attrs["data_types"] = {
    "indices_0": coo.row.dtype.__str__(),
    "indices_1": coo.col.dtype.__str__(),
    "values": coo.data.dtype.__str__(),
}
```