### PR TITLE
Feature: Adding a sparse gradient tracker for scipy.sparse.linalg.spsolve_triangular

### DIFF
--- a/config/training_config.yaml
+++ b/config/training_config.yaml
@@ -7,14 +7,14 @@ forcings: merit_conus_v6.18_snow
 name: ${version}-ddr_jrb-${forcings}
 
 data_sources:
-  conus_hydrofabric: /Users/taddbindas/projects/ddr/data/conus_nextgen.gpkg
-  local_hydrofabric: /Users/taddbindas/projects/ddr/data/jrb_2.gpkg
-  network: /Users/taddbindas/projects/ddr/data/network.zarr
-  transition_matrix: /Users/taddbindas/projects/ddr/data/conus_transition_matrices.zarr
-  statistics: /Users/taddbindas/projects/ddr/data/statistics
-  streamflow:  /Users/taddbindas/projects/ddr/data/streamflow
-  observations: /Users/taddbindas/projects/ddr/data/gages_9000.zarr
-  training_basins: /Users/taddbindas/projects/ddr/data/gages.csv
+  conus_hydrofabric: /projects/mhpi/data/hydrofabric/v2.2/conus_nextgen.gpkg
+  local_hydrofabric: /projects/mhpi/data/hydrofabric/v2.2/jrb_2.gpkg
+  network: /projects/mhpi/tbindas/ddr/data/network.zarr
+  transition_matrix: /projects/mhpi/data/hydrofabric/v2.2/conus_transition_matrices.zarr
+  statistics: /projects/mhpi/tbindas/ddr/data/statistics
+  streamflow:  /projects/mhpi/data/MERIT/streamflow/zarr/${forcings}/73
+  observations: /projects/mhpi/data/observations/gages_9000.zarr
+  training_basins: /projects/mhpi/tbindas/ddr/data/gages.csv
 
 train:
   batch_size: 1
@@ -67,7 +67,7 @@ params:
 
 np_seed: 1
 seed: 0
-device: cpu
+device: 0
 
 kan:
   hidden_size: 11

--- a/config/training_config.yaml
+++ b/config/training_config.yaml
@@ -7,14 +7,14 @@ forcings: merit_conus_v6.18_snow
 name: ${version}-ddr_jrb-${forcings}
 
 data_sources:
-  conus_hydrofabric: /projects/mhpi/data/hydrofabric/v2.2/conus_nextgen.gpkg
-  local_hydrofabric: /projects/mhpi/data/hydrofabric/v2.2/jrb_2.gpkg
-  network: /projects/mhpi/tbindas/ddr/data/network.zarr
-  transition_matrix: /projects/mhpi/data/hydrofabric/v2.2/conus_transition_matrices.zarr
-  statistics: /projects/mhpi/tbindas/ddr/data/statistics
-  streamflow:  /projects/mhpi/data/MERIT/streamflow/zarr/${forcings}/73
-  observations: /projects/mhpi/data/observations/gages_9000.zarr
-  training_basins: /projects/mhpi/tbindas/ddr/data/gages.csv
+  conus_hydrofabric: /Users/taddbindas/projects/ddr/data/conus_nextgen.gpkg
+  local_hydrofabric: /Users/taddbindas/projects/ddr/data/jrb_2.gpkg
+  network: /Users/taddbindas/projects/ddr/data/network.zarr
+  transition_matrix: /Users/taddbindas/projects/ddr/data/conus_transition_matrices.zarr
+  statistics: /Users/taddbindas/projects/ddr/data/statistics
+  streamflow:  /Users/taddbindas/projects/ddr/data/streamflow
+  observations: /Users/taddbindas/projects/ddr/data/gages_9000.zarr
+  training_basins: /Users/taddbindas/projects/ddr/data/gages.csv
 
 train:
   batch_size: 1
@@ -67,7 +67,7 @@ params:
 
 np_seed: 1
 seed: 0
-device: 0  # mps:0
+device: cpu
 
 kan:
   hidden_size: 11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ cpu = [
 cu124 = [
   "torch==2.6.0",
   "torchvision==0.21.0",
+  "cupy-cuda12x==13.4.0",
 ]
 
 [tool.uv]

--- a/src/ddr/routing/dmc.py
+++ b/src/ddr/routing/dmc.py
@@ -198,11 +198,6 @@ class dmc(torch.nn.Module):
             A_values = mapper.map(c_1_)
             try:
                 if self.cfg.device == "cpu":
-                    # A_dense = self.network.clone()
-                    # A_dense[dense_rows, dense_cols] = A_values
-                    # x = solve_triangular(A_dense, b, upper=False)
-                    # solution = x.squeeze()
-                # else:
                     solution = triangular_sparse_solve(
                         A_values, 
                         mapper.crow_indices, 
@@ -211,6 +206,11 @@ class dmc(torch.nn.Module):
                         True,   # lower=True 
                         False   # unit_diagonal=False
                     )
+                else:
+                    A_dense = self.network.clone()
+                    A_dense[dense_rows, dense_cols] = A_values
+                    x = solve_triangular(A_dense, b, upper=False)
+                    solution = x.squeeze()
                 
             except torch.cuda.OutOfMemoryError as e:
                 raise torch.cuda.OutOfMemoryError from e

--- a/src/ddr/routing/dmc.py
+++ b/src/ddr/routing/dmc.py
@@ -197,21 +197,19 @@ class dmc(torch.nn.Module):
             c_1_[0] = 1.0
             A_values = mapper.map(c_1_)
             try:
-                if self.cfg.device == "cpu":
-                    solution = triangular_sparse_solve(
-                        A_values, 
-                        mapper.crow_indices, 
-                        mapper.col_indices, 
-                        b,
-                        True,   # lower=True 
-                        False   # unit_diagonal=False
-                    )
-                else:
-                    A_dense = self.network.clone()
-                    A_dense[dense_rows, dense_cols] = A_values
-                    x = solve_triangular(A_dense, b, upper=False)
-                    solution = x.squeeze()
-                
+                solution = triangular_sparse_solve(
+                    A_values, 
+                    mapper.crow_indices, 
+                    mapper.col_indices, 
+                    b,
+                    True,  # lower=True 
+                    False,  # unit_diagonal=False
+                    self.cfg.device  # device
+                )
+                # A_dense = self.network.clone()
+                # A_dense[dense_rows, dense_cols] = A_values
+                # x = solve_triangular(A_dense, b, upper=False)
+                # solution = x.squeeze()                
             except torch.cuda.OutOfMemoryError as e:
                 raise torch.cuda.OutOfMemoryError from e
             

--- a/src/ddr/routing/dmc.py
+++ b/src/ddr/routing/dmc.py
@@ -10,9 +10,12 @@ from ddr.routing.utils import (
     PatternMapper,
     denormalize,
     get_network_idx,
+    # RiverNetworkMatrix,
+    triangular_sparse_solve
 )
 
 log = logging.getLogger(__name__)
+
 
 def _log_base_q(x, q):
     return torch.log(x) / torch.log(torch.tensor(q, dtype=x.dtype))
@@ -187,21 +190,32 @@ class dmc(torch.nn.Module):
             i_t = torch.matmul(self.network, self._discharge_t)
             q_l = q_prime_clamp
 
-            b_array = (c_2 * i_t) + (c_3 * self._discharge_t) + (c_4 * q_l)
-            b = b_array.unsqueeze(-1)
+            b = (c_2 * i_t) + (c_3 * self._discharge_t) + (c_4 * q_l)
+            # b = b_array.unsqueeze(-1)
             c_1 = (self.t - (2.0 * k * x_storage)) / denom
             c_1_ = c_1 * -1
             c_1_[0] = 1.0
             A_values = mapper.map(c_1_)
-            A_dense = self.network.clone()
-            A_dense[dense_rows, dense_cols] = A_values
-
             try:
-                x = solve_triangular(A_dense, b, upper=False)
+                if self.cfg.device == "cpu":
+                    # A_dense = self.network.clone()
+                    # A_dense[dense_rows, dense_cols] = A_values
+                    # x = solve_triangular(A_dense, b, upper=False)
+                    # solution = x.squeeze()
+                # else:
+                    solution = triangular_sparse_solve(
+                        A_values, 
+                        mapper.crow_indices, 
+                        mapper.col_indices, 
+                        b,
+                        True,   # lower=True 
+                        False   # unit_diagonal=False
+                    )
+                
             except torch.cuda.OutOfMemoryError as e:
                 raise torch.cuda.OutOfMemoryError from e
-            sol = x.squeeze()
-            q_t1 = torch.clamp(sol, min=self.discharge_lb)
+            
+            q_t1 = torch.clamp(solution, min=self.discharge_lb)
             
             for i, gage_idx in enumerate(gage_indices):
                 output[i, timestep] = torch.sum(q_t1[gage_idx])

--- a/src/ddr/routing/utils.py
+++ b/src/ddr/routing/utils.py
@@ -2,112 +2,14 @@ import logging
 import warnings
 
 import torch
+import numpy as np
+import scipy.sparse as sp
+from scipy.sparse.linalg import spsolve_triangular
 
 log = logging.getLogger(__name__)
 
 # Disable prototype warnings and such
 warnings.filterwarnings(action="ignore", category=UserWarning)
-
-
-class SolverError(Exception):
-    """Custom exception for solver-related errors"""
-
-    pass
-
-
-class RiverNetworkMatrix(torch.autograd.Function):
-    """Custom autograd function for sparse tensor operations in river routing."""
-
-    @staticmethod
-    def forward(*args, **kwargs):
-        """Create a sparse CSR tensor from input values and indices.
-
-        Parameters
-        ----------
-        ctx : Context
-            Context object for storing information for backward computation.
-        A_values : torch.Tensor
-            Values for the sparse tensor.
-        crow_indices : torch.Tensor
-            Compressed row indices.
-        col_indices : torch.Tensor
-            Column indices.
-
-        Returns
-        -------
-        torch.sparse_csr_tensor
-            Constructed sparse CSR tensor.
-        """
-        ctx, A_values, crow_indices, col_indices = args
-        A_csr = torch.sparse_csr_tensor(
-            crow_indices,
-            col_indices,
-            A_values,
-        )
-        ctx.save_for_backward(
-            A_values,
-            A_csr,
-            crow_indices,
-            col_indices,
-        )
-        return A_csr
-
-    @staticmethod
-    def backward(*args):
-        """Compute gradients for the backward pass.
-
-        Parameters
-        ----------
-        ctx : Context
-            Context object containing saved tensors.
-        grad_output : torch.Tensor
-            Gradient of the loss with respect to the output.
-
-        Returns
-        -------
-        tuple
-            Gradients with respect to the inputs.
-        """
-
-        def extract_csr_values(
-            col_indices: torch.Tensor,
-            crow_indices: torch.Tensor,
-            dense_matrix: torch.Tensor,
-        ) -> torch.Tensor:
-            """Extract values from dense matrix using CSR format indices.
-
-            Parameters
-            ----------
-            col_indices : torch.Tensor
-                Column indices for sparse matrix.
-            crow_indices : torch.Tensor
-                Compressed row indices.
-            dense_matrix : torch.Tensor
-                Dense matrix to extract values from.
-
-            Returns
-            -------
-            torch.Tensor
-                Extracted values in CSR format.
-            """
-            crow_indices_list = crow_indices.tolist()
-            col_indices_list = col_indices.tolist()
-            rows = []
-            cols = []
-            for i in range(len(crow_indices_list) - 1):
-                start, end = crow_indices_list[i], crow_indices_list[i + 1]
-                these_cols = col_indices_list[start:end]
-                these_rows = [i] * len(these_cols)
-                rows.extend(these_rows)
-                cols.extend(these_cols)
-            values = dense_matrix[rows, cols]
-            return values
-
-        ctx, grad_output = args
-        with torch.no_grad():
-            A_values, A_csr, crow_indices, col_indices = ctx.saved_tensors
-            grad_A_values = extract_csr_values(col_indices, crow_indices, grad_output)
-        return grad_A_values, None, None, None
 
 
 class PatternMapper:
@@ -299,3 +201,165 @@ def denormalize(value: torch.Tensor, bounds: list[float]) -> torch.Tensor:
     """
     output = (value * (bounds[1] - bounds[0])) + bounds[0]
     return output
+
+
+class TriangularSparseSolver(torch.autograd.Function):
+    """Custom autograd function for solving triangular sparse linear systems.
+    """
+    
+    @staticmethod
+    def forward(ctx, A_values, crow_indices, col_indices, b, lower, unit_diagonal):
+        """Solve the sparse triangular linear system.
+        
+        Parameters
+        ----------
+        ctx : Context
+            Context object for storing information for backward computation.
+        A_values : torch.Tensor
+            Values for the sparse tensor.
+        crow_indices : torch.Tensor
+            Compressed row indices.
+        col_indices : torch.Tensor
+            Column indices.
+        b : torch.Tensor
+            Dense tensor representing the right-hand side.
+        lower : bool, (True)
+            Whether to solve a lower triangular system. Default is True.
+        unit_diagonal : bool, (True)
+            Whether the diagonal of the matrix consists of ones. Default is False.
+            
+        Returns
+        -------
+        torch.Tensor
+            Solution to the system Ax = b.
+        """
+        # Start logging the solve process
+        # log.info(f"TriangularSparseSolver forward: matrix size = {len(crow_indices)-1}x{len(crow_indices)-1}, " 
+        #         f"nnz = {len(A_values)}, b shape = {b.shape}")
+        
+        # Check if we have a single right-hand side or multiple
+        # if b.dim() > 1:
+        # b = b.squeeze(-1)  # Remove singleton dimension if present
+        
+        # Convert PyTorch tensors to NumPy for SciPy
+        crow_np = crow_indices.cpu().numpy().astype(np.int32)
+        col_np = col_indices.cpu().numpy().astype(np.int32)
+        data_np = A_values.cpu().numpy().astype(np.float64)
+        b_np = b.cpu().numpy().astype(np.float64)
+        
+        # Matrix dimensions
+        n = len(crow_np) - 1
+        
+        # Create SciPy CSR matrix
+        A_scipy = sp.csr_matrix((data_np, col_np, crow_np), shape=(n, n))
+        
+        # Log sparsity information
+        # nnz = len(data_np)
+        # sparsity = 100.0 * (1.0 - nnz / (n * n))
+        # log.info(f"Matrix sparsity: {sparsity:.2f}% ({nnz} non-zeros out of {n*n})")
+        
+        # Try to solve the system
+        try:
+            # Single right-hand side
+            x_np = spsolve_triangular(
+                A_scipy, b_np, lower=lower, unit_diagonal=unit_diagonal
+            )
+                
+            # log.info("Triangular sparse solve completed successfully")
+        except Exception as e:
+            log.error(f"Triangular sparse solve failed: {e}")
+            raise SolverError(f"SciPy triangular sparse solver failed: {e}")
+        
+        # Convert solution back to PyTorch tensor
+        x = torch.tensor(x_np, dtype=b.dtype, device=b.device)
+                
+        # Save data for backward pass
+        ctx.save_for_backward(A_values, crow_indices, col_indices, x, b)
+        ctx.lower = lower
+        ctx.unit_diagonal = unit_diagonal
+        
+        return x
+    
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Compute gradients for the backward pass.
+        
+        Parameters
+        ----------
+        ctx : Context
+            Context object containing saved tensors.
+        grad_output : torch.Tensor
+            Gradient of the loss with respect to the output.
+            
+        Returns
+        -------
+        tuple
+            Gradients with respect to inputs.
+        """
+        A_values, crow_indices, col_indices, x, b = ctx.saved_tensors
+        lower = ctx.lower
+        unit_diagonal = ctx.unit_diagonal
+        
+        # Make sure grad_output has the right shape
+        if grad_output.dim() > 1 and x.dim() == 1:
+            grad_output = grad_output.squeeze(-1)
+        
+        # log.info(f"TriangularSparseSolver backward: grad_output shape = {grad_output.shape}")
+        
+        # For backward pass with triangular matrices, we need to be careful
+        # Solve transposed system: If A is lower triangular, A^T is upper triangular
+        transposed_lower = not lower
+        
+        # Convert to COO format for easier transposition
+        # First, extract the (row, col) pairs from CSR format
+        n = len(crow_indices) - 1
+        rows = []
+        cols = []
+        for i in range(n):
+            start, end = crow_indices[i].item(), crow_indices[i+1].item()
+            for j in range(start, end):
+                rows.append(i)
+                cols.append(col_indices[j].item())
+        
+        # Create transposed indices (swap rows and cols)
+        transposed_indices = torch.tensor([cols, rows], dtype=torch.int64, device=A_values.device)
+        
+        # Create COO tensor for the transposed matrix
+        A_T_values = A_values.clone()  # Values stay the same for transpose
+        A_T_coo = torch.sparse_coo_tensor(
+            transposed_indices, A_T_values, size=(n, n), device=A_values.device
+        )
+        
+        # Convert to CSR for efficient solving
+        A_T_csr = A_T_coo.to_sparse_csr()
+        A_T_crow = A_T_csr.crow_indices()
+        A_T_col = A_T_csr.col_indices()
+        A_T_values = A_T_csr.values()
+        
+        # Solve the transposed system to get gradb
+        gradb = TriangularSparseSolver.apply(
+            A_T_values, A_T_crow, A_T_col, grad_output, transposed_lower, unit_diagonal   
+        )
+        
+        # For gradA, we need to compute -gradb * x^T
+        # But since A is sparse, we only need the gradients at the non-zero locations
+        if A_values.requires_grad:
+            # Extract non-zero pattern
+            gradA_values = torch.zeros_like(A_values)
+            
+            # For each non-zero in the original matrix
+            for i in range(n):
+                start, end = crow_indices[i].item(), crow_indices[i+1].item()
+                for j_idx in range(start, end):
+                    j = col_indices[j_idx].item()
+                    # Compute gradient for this location: -gradb[i] * x[j]
+                    gradA_values[j_idx] = -gradb[i] * x[j]
+            
+            # log.info(f"Computed gradient w.r.t. A values with shape {gradA_values.shape}")
+            
+            return gradA_values, None, None, gradb, None, None
+        else:
+            return None, None, None, gradb, None, None
+
+
+triangular_sparse_solve = TriangularSparseSolver.apply

--- a/src/ddr/routing/utils.py
+++ b/src/ddr/routing/utils.py
@@ -8,6 +8,14 @@ from scipy.sparse.linalg import spsolve_triangular
 
 log = logging.getLogger(__name__)
 
+# Try to import cupy - if not available, we'll handle gracefully during runtime
+try:
+    import cupy as cp
+    from cupyx.scipy.sparse import csr_matrix as cp_csr_matrix
+    from cupyx.scipy.sparse.linalg import spsolve_triangular as cp_spsolve_triangular
+except ImportError:
+    log.warning("CuPy not available. GPU solver functionality will be disabled.")
+
 # Disable prototype warnings and such
 warnings.filterwarnings(action="ignore", category=UserWarning)
 
@@ -208,7 +216,7 @@ class TriangularSparseSolver(torch.autograd.Function):
     """
     
     @staticmethod
-    def forward(ctx, A_values, crow_indices, col_indices, b, lower, unit_diagonal):
+    def forward(ctx, A_values, crow_indices, col_indices, b, lower, unit_diagonal, device):
         """Solve the sparse triangular linear system.
         
         Parameters
@@ -233,31 +241,50 @@ class TriangularSparseSolver(torch.autograd.Function):
         torch.Tensor
             Solution to the system Ax = b.
         """
-       
         # convert to Scipy csr
         crow_np = crow_indices.cpu().numpy().astype(np.int32)
         col_np = col_indices.cpu().numpy().astype(np.int32)
         data_np = A_values.cpu().numpy().astype(np.float64)
         b_np = b.cpu().numpy().astype(np.float64)
-        
+            
         n = len(crow_np) - 1
         
-        A_scipy = sp.csr_matrix((data_np, col_np, crow_np), shape=(n, n))
-        
-        try:
-            x_np = spsolve_triangular(
-                A_scipy, b_np, lower=lower, unit_diagonal=unit_diagonal
-            )
+        if device == "cpu":
+            A_scipy = sp.csr_matrix((data_np, col_np, crow_np), shape=(n, n))
+            try:
+                x_np = spsolve_triangular(
+                    A_scipy, b_np, lower=lower, unit_diagonal=unit_diagonal
+                )
+                    
+            except Exception as e:
+                log.error(f"Triangular sparse solve failed: {e}")
+                raise ValueError(f"SciPy triangular sparse solver failed: {e}")
+        else:
+            device = cp.cuda.Device(device)  # Device 1
+            with device:
+                data_cp = cp.array(data_np)
+                indices_cp = cp.array(col_np)
+                indptr_cp = cp.array(crow_np)
+                b_cp = cp.array(b_np)
                 
-        except Exception as e:
-            log.error(f"Triangular sparse solve failed: {e}")
-            raise ValueError(f"SciPy triangular sparse solver failed: {e}")
-        
+                # Create CuPy CSR matrix
+                A_cp = cp_csr_matrix((data_cp, indices_cp, indptr_cp), shape=(n, n))
+                
+                # Solve on GPU
+                x_cp = cp_spsolve_triangular(
+                    A_cp, b_cp, lower=lower, unit_diagonal=unit_diagonal
+                )
+                
+                # Transfer solution back to CPU
+                x_np = cp.asnumpy(x_cp)
+                log.debug("GPU solver completed successfully")
+            
         # Convert solution back to PyTorch tensor and save gradients/states
         x = torch.tensor(x_np, dtype=b.dtype, device=b.device)
         ctx.save_for_backward(A_values, crow_indices, col_indices, x, b)
         ctx.lower = lower
         ctx.unit_diagonal = unit_diagonal
+        ctx.device = device
         
         return x
     
@@ -280,6 +307,7 @@ class TriangularSparseSolver(torch.autograd.Function):
         A_values, crow_indices, col_indices, x, b = ctx.saved_tensors
         lower = ctx.lower
         unit_diagonal = ctx.unit_diagonal
+        device = ctx.device
             
         # NOTE For backward pass with triangular matrices, we need to be careful
         # Since A is lower triangular, A^T is upper triangular
@@ -309,7 +337,7 @@ class TriangularSparseSolver(torch.autograd.Function):
         
         # Solve the transposed system to get gradb
         gradb = TriangularSparseSolver.apply(
-            A_T_values, A_T_crow, A_T_col, grad_output, transposed_lower, unit_diagonal   
+            A_T_values, A_T_crow, A_T_col, grad_output, transposed_lower, unit_diagonal, device   
         )
         
         # NOTE: For gradA, we need to compute -gradb * x^T
@@ -324,9 +352,9 @@ class TriangularSparseSolver(torch.autograd.Function):
                     # Compute gradient for this location: -gradb[i] * x[j]
                     gradA_values[j_idx] = -gradb[i] * x[j]
                         
-            return gradA_values, None, None, gradb, None, None
+            return gradA_values, None, None, gradb, None, None, None
         else:
-            return None, None, None, gradb, None, None
+            return None, None, None, gradb, None, None, None
 
 
 triangular_sparse_solve = TriangularSparseSolver.apply


### PR DESCRIPTION
# Added:
- the `TriangularSparseSolver` class to track gradients during sparse linear solves
- support in dMC to run this function using: `triangular_sparse_solve`
- Added `cupy` support for GPU runs
  - memory footprint reduced by 91%

# Tests:
- validated the outputs of:
```python
solution = triangular_sparse_solve(
    A_values, 
    mapper.crow_indices, 
    mapper.col_indices, 
    b,
    True,   # lower=True 
    False   # unit_diagonal=False
)
```

are the same as 
```python
A_dense = self.network.clone()
A_dense[dense_rows, dense_cols] = A_values
x = solve_triangular(A_dense, b, upper=False)
solution = x.squeeze()
```
