### PR TITLE
Fix: speed improvements to adjacency matrix using polars + pyiceberg rather than pandas

### DIFF
--- a/engine/README.md
+++ b/engine/README.md
@@ -9,3 +9,8 @@ How to run adjacency matrix:
 ```python
 python engine/adjacency.py <path to hydrofabric gpkg> <store key> <store path>
 ```
+
+To install these dependencies, please run the following command from the project root
+```sh
+uv sync --extra engine
+```

--- a/engine/adjacency.py
+++ b/engine/adjacency.py
@@ -166,7 +166,7 @@ def coo_to_zarr(coo: sparse.coo_matrix, ts_order: list[str], out_path: Path) -> 
     store = zarr.storage.LocalStore(root=out_path)
     root = zarr.create_group(store=store)
 
-    zarr_order = np.array([int(_id.split("-")[1]) for _id in ts_order], dtype=np.int32)
+    zarr_order = np.array([int(float(_id.split("-")[1])) for _id in ts_order], dtype=np.int32)
 
     indices_0 = root.create_array(name="indices_0", shape=coo.row.shape, dtype=coo.row.dtype)
     indices_1 = root.create_array(name="indices_1", shape=coo.col.shape, dtype=coo.row.dtype)

--- a/engine/adjacency.py
+++ b/engine/adjacency.py
@@ -88,68 +88,28 @@ def create_matrix(fp: LazyFrame, network: LazyFrame, ghost=False) -> tuple[spars
     # in this graph form -- each waterbody/flowpath is a node and each nexus is a directed edge
     # All flowpaths are nodes, add them upfront...
     gidx = graph.add_nodes_from(fp.keys())
-    for row in tqdm(fp_df.iter_rows(named=True), desc="finding indices", total=len(fp_df)):
-        id_val = row["id"]
-        nex = row["toid"]
-
-        # Fast lookup instead of filtering each time
-        ds_wb = network_dict.get(nex)
-
+    for idx in tqdm(gidx, desc="Building network graph"):
+        id = graph.get_node_data(idx)
+        nex = fp[id][1] # the downstream nexus id
+        terminal = False
+        ds_wb = network.get(nex)
         if ds_wb is None:
-            print("Terminal nex???", nex)
-            ds_wb = np.nan
-
-        if pd.isna(ds_wb):
-            if ghost:
+            # This allows a ghost node to be used by multiple upstream
+            # flowpaths which accumulate at the same location
+            # If we find a terminal we haven't seen before, we create a new ghost node
+            if ghost and not id.startswith("ghost-"):
+                ghost_node = graph.add_node(f"ghost-{_tnx_counter}")
                 ds_wb = f"ghost-{_tnx_counter}"
-                # Track changes to apply later
-                network_updates[nex] = ds_wb  # Point nexus to ghost
-                ghost_nodes_to_add.append(
-                    {
-                        "id": ds_wb,
-                        "toid": None,  # Ghost points to nothing
-                    }
-                )
-                network_dict[nex] = ds_wb
-                network_dict[ds_wb] = None
+                network[nex] = ds_wb
+                network[ds_wb] = None
+                fp[ds_wb] = (ghost_node, None)
                 _tnx_counter += 1
+            else:
+                terminal = True
+        if not terminal:
+            graph.add_edge(idx, fp[ds_wb][0], nex)
 
-        # Add a node to the sorter, ds_wb is the node, id_val is its predecessor
-        sorter.add(ds_wb, id_val)
-
-    # Apply network updates efficiently in Polars
-    if network_updates or ghost_nodes_to_add:
-        # Update existing network entries
-        if network_updates:
-            network_df = network_df.with_columns(
-                [
-                    pl.when(pl.col("id").is_in(list(network_updates.keys())))
-                    .then(pl.col("id").map_elements(lambda x: network_updates.get(x), return_dtype=pl.String))
-                    .otherwise(pl.col("toid"))
-                    .alias("toid")
-                ]
-            )
-
-        # Add ghost nodes to network
-        if ghost_nodes_to_add:
-            ghost_network_df = pl.DataFrame(ghost_nodes_to_add, schema={"id": pl.String, "toid": pl.String})
-            network_df = pl.concat([network_df, ghost_network_df])
-
-        # Add ghost nodes to flowpaths
-        if ghost_nodes_to_add:
-            ghost_fp_df = pl.DataFrame(ghost_nodes_to_add, schema={"id": pl.String, "toid": pl.String})
-            fp_df = pl.concat([fp_df, ghost_fp_df])
-
-    # Get topological sort order
-    if ghost:
-        ts_order = list(sorter.static_order())
-    else:
-        ts_order = list(filter(lambda s: not pd.isna(s), sorter.static_order()))
-
-    # Create dictionaries for matrix building
-    fp_dict = dict(zip(fp_df["id"].to_list(), fp_df["toid"].to_list(), strict=True))
-    network_dict = dict(zip(network_df["id"].to_list(), network_df["toid"].to_list(), strict=True))
-    id_to_pos = {id_val: pos for pos, id_val in enumerate(ts_order)}
+    ts_order = rx.topological_sort(graph)
 
     # Build sparse matrix
     row_idx = []

--- a/engine/adjacency.py
+++ b/engine/adjacency.py
@@ -56,9 +56,6 @@ def index_matrix(matrix: np.ndarray, fp: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     return matrix_df
 
 
-_tnx_counter = 0
-
-
 def create_matrix(fp: LazyFrame, network: LazyFrame, ghost=False) -> tuple[sparse.coo_matrix, list[str]]:
     """
     Create a lower triangular adjacency matrix from flowpaths and network dataframes.
@@ -75,7 +72,7 @@ def create_matrix(fp: LazyFrame, network: LazyFrame, ghost=False) -> tuple[spars
     np.ndarray
         Lower triangular adjacency matrix.
     """
-    global _tnx_counter
+    _tnx_counter = 0
 
     # Toposort for the win
     sorter = gl.TopologicalSorter()

--- a/engine/adjacency.py
+++ b/engine/adjacency.py
@@ -13,8 +13,8 @@ from a NextGen hydrofabric and writing a sparse zarr group
 
 from pathlib import Path
 
-import geopandas as gpd
 import numpy as np
+import pandas as pd
 import rustworkx as rx
 import zarr
 from polars import LazyFrame
@@ -23,7 +23,7 @@ from scipy import sparse
 from tqdm import tqdm
 
 
-def index_matrix(matrix: np.ndarray, fp: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+def index_matrix(matrix: np.ndarray, fp: pd.DataFrame) -> pd.DataFrame:
     """
     Create a 2D dataframe with rows and columns indexed by flowpath IDs
     and values from the lower triangular adjacency matrix.
@@ -32,18 +32,16 @@ def index_matrix(matrix: np.ndarray, fp: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     ----------
     matrix : np.ndarray
         Lower triangular adjacency matrix.
-    fp : gpd.GeoDataFrame
+    fp : pd.DataFrame
         Flowpaths dataframe with 'toid' column indicating downstream nexus IDs.
 
     Returns
     -------
-    gpd.GeoDataFrame
+    pd.DataFrame
         matrix dataframe with flowpath IDs as index and columns
     """
-    # Create a new GeoDataFrame with the same index as the flowpaths
-    matrix_df = gpd.GeoDataFrame(
-        index=fp.index, columns=fp.index, data=np.zeros((len(fp), len(fp)), dtype=int)
-    )
+    # Create a new DataFrame with the same index as the flowpaths
+    matrix_df = pd.DataFrame(index=fp.index, columns=fp.index, data=np.zeros((len(fp), len(fp)), dtype=int))
     matrix_df.rename_axis("to", inplace=True)
     matrix_df.rename_axis("from", axis=1, inplace=True)
     # Fill the dataframe with the values from the matrix

--- a/engine/adjacency.py
+++ b/engine/adjacency.py
@@ -155,8 +155,6 @@ def coo_to_zarr(coo: sparse.coo_matrix, ts_order: list[str], out_path: Path) -> 
         Lower triangular adjacency matrix.
     ts_order : list[str]
         Topological sort order of flowpaths.
-    name : str
-        Name of the zarr group to create.
     out_path : Path | str | None, optional
         Path to save the zarr group. If None, defaults to current working directory with name appended.
 

--- a/engine/adjacency.py
+++ b/engine/adjacency.py
@@ -69,8 +69,9 @@ def create_matrix(fp: LazyFrame, network: LazyFrame, ghost=False) -> tuple[spars
 
     Returns
     -------
-    np.ndarray
-        Lower triangular adjacency matrix.
+    tuple[sparse.coo_matrix, list[str]]
+        tuple[0]: A scipy sparse matrix in COO format
+        tuple[1]: Topological ordering of Flowpaths
     """
     _tnx_counter = 0
 

--- a/engine/adjacency.py
+++ b/engine/adjacency.py
@@ -131,10 +131,19 @@ def create_matrix(fp: LazyFrame, network: LazyFrame, ghost=False) -> tuple[spars
     matrix = sparse.coo_matrix( (np.ones(len(row), dtype=np.uint8), (row, col)), shape=(len(ts_order), len(ts_order)), dtype=np.uint8)
     
     # Ensure matrix is lower triangular
-    assert np.all(coo.row >= coo.col), "Matrix is not lower triangular"
-    _tnx_counter = 0
-    return coo, ts_order
+    assert np.all(matrix.row >= matrix.col), "Matrix is not lower triangular"
+    # assert sparse.linalg.is_sptriangular(matrix)[0] == True
+    
+    # If we want to get updated flowpath and network dataframes,
+    # we can create them from the topological sort order
+    # fp = pl.DataFrame({"id": [graph.get_node_data(gidx) for gidx in ts_order], "toid": [fp.get(id) for id in ts_order]})
+    # technically, the network dataframe doesn't need to worry about sort order...just recreate
+    # from the possibly updated network dictionary
+    # network = pl.DataFrame( {"id": network.keys(), "toid": network.values()})
+    # With polars frames, these would need to be returned as new objects
+    # from this function.
 
+    return matrix, id_order
 
 def coo_to_zarr(coo: sparse.coo_matrix, ts_order: list[str], out_path: Path) -> None:
     """

--- a/engine/build_warehouse.py
+++ b/engine/build_warehouse.py
@@ -2,12 +2,17 @@ import argparse
 from pathlib import Path
 
 import geopandas as gpd
+import pyarrow.parquet as pq
 from pyiceberg.catalog import load_catalog
 from pyiceberg.exceptions import NamespaceAlreadyExistsError
-import pyarrow.parquet as pq
 
 
 def build_tables(file: Path):
+    """Build iceberg tables from a hydrofabric geopackage
+
+    Args:
+        file (Path): path to the hydrofabric geopackage
+    """
     file_dir = file.parent
     warehouse_path = Path("/tmp/warehouse")
     warehouse_path.mkdir(exist_ok=True)
@@ -48,8 +53,11 @@ def build_tables(file: Path):
             iceberg_table.append(arrow_table)
     print(f"Build successful. Files written into metadata store @ {warehouse_path}")
 
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="A module to convert a hydrofabric geopackage into a pyiceberg warehouse")
+    parser = argparse.ArgumentParser(
+        description="A module to convert a hydrofabric geopackage into a pyiceberg warehouse"
+    )
     parser.add_argument("--file", required=True, help="The hydrofabric geopackage to build a warehouse from")
 
     args = parser.parse_args()
@@ -60,4 +68,3 @@ if __name__ == "__main__":
         msg = f"File not found: {file}"
         print(msg)
         raise FileNotFoundError(msg)
-    

--- a/engine/build_warehouse.py
+++ b/engine/build_warehouse.py
@@ -11,14 +11,8 @@ def build_tables(file: Path):
     file_dir = file.parent
     warehouse_path = Path("/tmp/warehouse")
     warehouse_path.mkdir(exist_ok=True)
-    catalog_settings = {
-        "type": "sql",
-        "uri": f"sqlite:///{warehouse_path}/pyiceberg_catalog.db",
-        "warehouse": f"file://{warehouse_path}",
-    }
-
     namespace = "hydrofabric"
-    catalog = load_catalog(namespace, **catalog_settings)
+    catalog = load_catalog(namespace)
     try:
         catalog.create_namespace(namespace)
     except NamespaceAlreadyExistsError:

--- a/engine/build_warehouse.py
+++ b/engine/build_warehouse.py
@@ -1,0 +1,69 @@
+import argparse
+from pathlib import Path
+
+import geopandas as gpd
+from pyiceberg.catalog import load_catalog
+from pyiceberg.exceptions import NamespaceAlreadyExistsError
+import pyarrow.parquet as pq
+
+
+def build_tables(file: Path):
+    file_dir = file.parent
+    warehouse_path = Path("/tmp/warehouse")
+    warehouse_path.mkdir(exist_ok=True)
+    catalog_settings = {
+        "type": "sql",
+        "uri": f"sqlite:///{warehouse_path}/pyiceberg_catalog.db",
+        "warehouse": f"file://{warehouse_path}",
+    }
+
+    namespace = "hydrofabric"
+    catalog = load_catalog(namespace, **catalog_settings)
+    try:
+        catalog.create_namespace(namespace)
+    except NamespaceAlreadyExistsError:
+        print(f"Namespace {namespace} already exists")
+    layers = [
+        "divide-attributes",
+        "divides",
+        "flowpath-attributes-ml",
+        "flowpath-attributes",
+        "flowpaths",
+        "hydrolocations",
+        "lakes",
+        "network",
+        "nexus",
+        "pois",
+    ]
+    for layer in layers:
+        print(f"Building layer: {layer}")
+        if catalog.table_exists(f"{namespace}.{layer}"):
+            print(f"Table {layer} already exists. Skipping build")
+        else:
+            parquet_file = file_dir / f"{layer}.parquet"
+            if parquet_file.exists() is False:
+                print(f"Converting layer: {layer} to parquet")
+                gdf = gpd.read_file(file, layer=layer)
+                gdf.to_parquet(parquet_file)
+            arrow_table = pq.read_table(parquet_file)
+            iceberg_table = catalog.create_table(
+                f"{namespace}.{layer}",
+                schema=arrow_table.schema,
+                location=str(warehouse_path / "data"),
+            )
+            iceberg_table.append(arrow_table)
+    print(f"Build successful. Files written into metadata store @ {warehouse_path}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="A module to convert a hydrofabric geopackage into a pyiceberg warehouse")
+    parser.add_argument("--file", required=True, help="The hydrofabric geopackage to build a warehouse from")
+
+    args = parser.parse_args()
+    file = Path(args.file)
+    if file.exists():
+        build_tables(file=file)
+    else:
+        msg = f"File not found: {file}"
+        print(msg)
+        raise FileNotFoundError(msg)
+    

--- a/engine/tests/test_adjacency.py
+++ b/engine/tests/test_adjacency.py
@@ -11,7 +11,6 @@ Tests for functionality of the adjacency module.
 import tempfile
 from pathlib import Path
 
-import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pytest
@@ -112,8 +111,8 @@ class TestIndexMatrix:
             fp_reindexed = fp_pandas.reindex(ts_order)
             result = index_matrix(matrix, fp_reindexed)
 
-        # Check that the result is a GeoDataFrame
-        assert isinstance(result, gpd.GeoDataFrame)
+        # Check that the result is a DataFrame
+        assert isinstance(result, pd.DataFrame)
         # Check that the matrix dimensions match
         assert result.shape == matrix.shape
         # Check that the data matches the matrix

--- a/engine/tests/test_adjacency.py
+++ b/engine/tests/test_adjacency.py
@@ -1,7 +1,9 @@
 """
 @author Nels Frazier
+@author Tadd Bindas
 
-@date June 12, 2025
+@date June 19, 2025
+@version 1.1
 
 Tests for functionality of the adjacency module.
 """
@@ -12,10 +14,13 @@ from pathlib import Path
 
 import geopandas as gpd
 import numpy as np
+import pandas as pd
 import pytest
+import polars as pl
 import zarr
+from scipy import sparse
 
-from ..adjacency import create_matrix, index_matrix, matrix_to_zarr  # noqa: TID252
+from ..adjacency import create_matrix, index_matrix, coo_to_zarr  # noqa: TID252
 
 # TODO consider generating random flowpaths and networks for more robust testing
 # then figure out a way to reporduce the same random flowpaths and networks
@@ -23,49 +28,49 @@ from ..adjacency import create_matrix, index_matrix, matrix_to_zarr  # noqa: TID
 
 
 @pytest.fixture
-def simple_flowpaths():
-    """Create a simple flowpaths GeoDataFrame for testing."""
+def simple_flowpaths() -> pl.LazyFrame:
+    """Create a simple flowpaths LazyFrame for testing."""
     data = {
-        "toid": ["nex-1", "nex-1"],  # Terminal flowpath has NaN
-        "geometry": [None],  # Simplified for testing
+        "id": ["wb-1", "wb-2"],
+        "toid": ["nex-1", "nex-1"],
     }
-    index = ["wb-1", "wb-2"]
-    fp = gpd.GeoDataFrame(data, index=index)
-    fp.index.name = "id"
+    fp = pl.LazyFrame(data, schema={"id": pl.String, "toid": pl.String})
     return fp
 
 
 @pytest.fixture
-def simple_network():
-    """Create a simple network GeoDataFrame for testing."""
+def simple_network() -> pl.LazyFrame:
+    """Create a simple network LazyFrame for testing."""
     data = {
-        "toid": [np.nan, "nex-1", "nex-1"],  # Terminal nexus has NaN
-        "geometry": [None],  # Simplified for testing
+        "id": ["nex-1", "wb-1", "wb-2"],
+        "toid": [None, "nex-1", "nex-1"],  # Use None for null values
     }
-    index = ["nex-1", "wb-1", "wb-2"]
-    network = gpd.GeoDataFrame(data, index=index)
-    network.index.name = "id"
+    network = pl.LazyFrame(data, schema={"id": pl.String, "toid": pl.String})
     return network
 
 
 @pytest.fixture
-def complex_flowpaths():
-    """Create a more complex flowpaths GeoDataFrame for testing."""
-    data = {"toid": ["nex-10", "nex-10", "nex-10", "nex-11", "nex-12", "nex-12"], "geometry": [None]}
-    index = ["wb-10", "wb-11", "wb-12", "wb-13", "wb-14", "wb-15"]
-    fp = gpd.GeoDataFrame(data, index=index)
-    fp.index.name = "id"
+def complex_flowpaths() -> pl.LazyFrame:
+    """Create a more complex flowpaths LazyFrame for testing."""
+    data = {
+        "id": ["wb-10", "wb-11", "wb-12", "wb-13", "wb-14", "wb-15"],
+        "toid": ["nex-10", "nex-10", "nex-10", "nex-11", "nex-12", "nex-12"]
+    }
+    fp = pl.LazyFrame(data, schema={"id": pl.String, "toid": pl.String})
     return fp
 
 
 @pytest.fixture
-def complex_network(complex_flowpaths):
-    """Create a more complex network GeoDataFrame for testing."""
-    data = {"toid": ["wb-13", "wb-14", np.nan] + complex_flowpaths["toid"].tolist(), "geometry": [None]}
-    index = ["nex-10", "nex-11", "nex-12"] + complex_flowpaths.index.tolist()
-    network = gpd.GeoDataFrame(data, index=index)
-    network.index.name = "id"
+def complex_network(complex_flowpaths: pl.LazyFrame) -> pl.LazyFrame:
+    """Create a more complex network LazyFrame for testing."""
+    flowpath_ids = complex_flowpaths.select(pl.col("id")).collect().to_series().to_list()
+    flowpath_toids = complex_flowpaths.select(pl.col("toid")).collect().to_series().to_list()
 
+    data = {
+        "id": ["nex-10", "nex-11", "nex-12"] + flowpath_ids,
+        "toid": ["wb-13", "wb-14", None] + flowpath_toids,
+    }
+    network = pl.LazyFrame(data, schema={"id": pl.String, "toid": pl.String})
     return network
 
 
@@ -85,16 +90,34 @@ class TestIndexMatrix:
         """Test basic functionality of index_matrix."""
         fp = request.getfixturevalue(fp)
         network = request.getfixturevalue(network)
-        matrix, ts_order = create_matrix(fp, network, ghost)
-
-        result = index_matrix(matrix, fp)
+        coo, ts_order = create_matrix(fp, network, ghost)
+        matrix = coo.toarray()
+        
+        # Convert original flowpaths for comparison, but only include original flowpaths (not ghost nodes)
+        fp_pandas = fp.collect().to_pandas().set_index("id")
+        
+        # Create a DataFrame that matches the matrix dimensions
+        if ghost:
+            # For ghost mode, we need to create a dataframe that includes ghost nodes
+            full_fp_data = []
+            for node_id in ts_order:
+                if node_id in fp_pandas.index:
+                    full_fp_data.append({"id": node_id, "toid": fp_pandas.loc[node_id, "toid"]})
+                else:
+                    # This is a ghost node
+                    full_fp_data.append({"id": node_id, "toid": np.nan})
+            
+            full_fp = pd.DataFrame(full_fp_data).set_index("id")
+            result = index_matrix(matrix, full_fp)
+        else:
+            # For non-ghost mode, reindex to match ts_order
+            fp_reindexed = fp_pandas.reindex(ts_order)
+            result = index_matrix(matrix, fp_reindexed)
 
         # Check that the result is a GeoDataFrame
         assert isinstance(result, gpd.GeoDataFrame)
-        # Check that the index matches the flowpaths
-        assert result.index.equals(fp.index)
-        # Check that the columns are named correctly
-        assert result.columns.equals(fp.index)
+        # Check that the matrix dimensions match
+        assert result.shape == matrix.shape
         # Check that the data matches the matrix
         assert np.array_equal(result.values, matrix)
         # Check that the index names are present
@@ -107,12 +130,10 @@ class TestIndexMatrix:
             t_cols = result.columns[result.columns.str.startswith("ghost-")]
             assert len(t_rows) > 0
             assert len(t_cols) > 0
-        else:
-            t_rows = result.index
-            t_cols = result.columns
-        assert len(t_rows) == len(t_cols)
-        assert len(t_rows.unique() == len(t_rows))
-        assert len(t_cols.unique() == len(t_cols))
+        
+        # Check uniqueness
+        assert len(result.index.unique()) == len(result.index)
+        assert len(result.columns.unique()) == len(result.columns)
 
 
 class TestAdjanceyMatrix:
@@ -131,54 +152,70 @@ class TestAdjanceyMatrix:
         """Test basic functionality of create_matrix."""
         fp = request.getfixturevalue(fp)
         network = request.getfixturevalue(network)
-        matrix, ts_order = create_matrix(fp, network, ghost)
-
+        coo, ts_order = create_matrix(fp, network, ghost)
+        matrix = coo.toarray()
+        
+        # Convert to pandas for easier inspection
+        fp_pandas = fp.collect().to_pandas().set_index("id")
+        
         # Validate matrix properties
         # Check that matrix is square and has correct dimensions
-        assert matrix.shape[0] == matrix.shape[1]
+        assert matrix.shape[0] == matrix.shape[1], "matrix is not square and does not have the correct dimensions"
         # Check that matrix contains only 0s and 1s
-        assert np.all((matrix == 0) | (matrix == 1))
+        assert np.all((matrix == 0) | (matrix == 1)), "matrix contains numbers other than 0s and 1s"
         # Check that diagonal is all zeros (no self-loops)
         assert np.all(np.diag(matrix) == 0)
         # Check that matrix is lower triangular
         assert np.allclose(matrix, np.tril(matrix))
 
-        paths = set(fp.index)
-        # NOTE this works becuase crete_matrix will modify the
-        # flowpath and network index when ghost is True
-        num_paths = len(paths)
-        assert matrix.shape[0] == num_paths
-        # Check that ts_order contains all flowpath IDs
-        assert len(ts_order) == num_paths
-        if not ghost:
-            ts_order = filter(lambda s: not s.startswith("ghost-"), ts_order)
-        assert set(ts_order) == paths
+        # Check dimensions match expected (note: ghost nodes may be added)
+        original_fp_count = len(fp_pandas)
+        if ghost:
+            # With ghost nodes, matrix should be larger than original flowpaths
+            assert matrix.shape[0] >= original_fp_count
+        else:
+            # Without ghost nodes, should match original flowpaths
+            assert matrix.shape[0] == original_fp_count
+            
+        # Check that ts_order length matches matrix dimensions
+        assert len(ts_order) == matrix.shape[0]
+        
+        # Check that original flowpath IDs are in ts_order
+        original_ids = set(fp_pandas.index)
+        ts_order_set = set(ts_order)
+        if ghost:
+            # All original IDs should be present (plus ghost nodes)
+            assert original_ids.issubset(ts_order_set)
+        else:
+            # Should exactly match original IDs
+            assert original_ids == ts_order_set
 
     def test_empty_dataframes(self):
         """Test behavior with empty dataframes."""
-        empty_fp = gpd.GeoDataFrame({"toid": []}, index=[])
-        empty_network = gpd.GeoDataFrame({"toid": []}, index=[])
-        empty_fp.index.name = "id"
-        empty_network.index.name = "id"
+        empty_fp = pl.LazyFrame({"id": [], "toid": []}, schema={"id": pl.String, "toid": pl.String})
+        empty_network = pl.LazyFrame({"id": [], "toid": []}, schema={"id": pl.String, "toid": pl.String})
 
-        matrix, ts_order = create_matrix(empty_fp, empty_network)
-
+        coo, ts_order = create_matrix(empty_fp, empty_network)
+        matrix = coo.toarray()
         assert matrix.shape == (0, 0)
         assert len(ts_order) == 0
 
     @pytest.mark.parametrize("ghost", [True, False])
     def test_single_flowpath(self, ghost):
         """Test with a single flowpath (terminal)."""
-        single_fp = gpd.GeoDataFrame({"toid": ["nex-1"]}, index=["wb-1"])
-        single_network = gpd.GeoDataFrame({"toid": [np.nan]}, index=["nex-1"], dtype="object")
-        single_fp.index.name = "id"
-        single_network.index.name = "id"
+        single_fp = pl.LazyFrame({"id": ["wb-1"], "toid": ["nex-1"]}, 
+                                schema={"id": pl.String, "toid": pl.String})
+        # Create network DataFrame properly
+        single_network = pl.LazyFrame({"id": ["nex-1"], "toid": [None]}, 
+                                     schema={"id": pl.String, "toid": pl.String})
 
-        matrix, ts_order = create_matrix(single_fp, single_network, ghost)
-
+        coo, ts_order = create_matrix(single_fp, single_network, ghost)
+        matrix = coo.toarray()
         if ghost:
             assert matrix.shape == (2, 2)
-            assert ts_order == ["wb-1", "ghost-0"]
+            assert len(ts_order) == 2
+            assert "wb-1" in ts_order
+            assert any(id.startswith("ghost-") for id in ts_order)
         else:
             assert matrix.shape == (1, 1)
             assert ts_order == ["wb-1"]
@@ -196,53 +233,34 @@ class TestAdjanceyMatrix:
         """Test matrix topology."""
         fp = request.getfixturevalue(fp)
         network = request.getfixturevalue(network)
-        # NJF an interesting result of the adjancency matrix is that
-        # columns that are all zeros are tailwater/terminal segments
-        # and the rows that are all zeros are headwater segments
-        matrix, ts_order = create_matrix(fp, network, ghost)
-
-        fp = fp.reindex(ts_order)
-        # Check matrix properties
-        # NOTE this works becuase crete_matrix will modify the
-        # flowpath and network index when ghost is True
-
-        # paths = set(fp.index)
-        # num_paths = len( paths )
-
-        # These are checked in test_create_matrix
-        # I don't think we need to check them again
-        # unless a new network/fixture is used for this function
-        # which isn't in create_matrix, so for now I'll leave these
-        # commented out here...
-        # assert matrix.shape[0] == num_paths
-        # assert np.allclose(matrix, np.tril(matrix))
-        # assert len(ts_order) == num_paths
-        # assert set(ts_order) == paths
+        coo, ts_order = create_matrix(fp, network, ghost)
+        matrix = coo.toarray()
+        
+        # Convert to pandas and reindex according to ts_order
+        fp_pandas = fp.collect().to_pandas().set_index("id").reindex(ts_order)
+        network_pandas = network.collect().to_pandas().set_index("id")
 
         # Test the values in the matrix
-        idx = fp.index
-        for i in range(len(fp)):
-            nex = fp.loc[idx[i]]["toid"]
-            if isinstance(nex, float) and np.isnan(nex):
+        idx = fp_pandas.index
+        for i in range(len(fp_pandas)):
+            if i >= len(idx):
+                break
+            nex = fp_pandas.loc[idx[i]]["toid"]
+            # Skip if nexus is null
+            if pd.isna(nex):
                 continue
-            ds = network.loc[nex]["toid"]
-            if isinstance(ds, float) and np.isnan(ds):
+            # Check if nexus exists in network
+            if nex not in network_pandas.index:
+                continue
+            ds = network_pandas.loc[nex]["toid"]
+            # Skip if downstream is null
+            if pd.isna(ds):
+                continue
+            # Check if downstream segment exists in the index
+            if ds not in idx:
                 continue
             j = idx.get_loc(ds)
-            assert matrix[j, i] == 1, f"Expected 1 at ({i}, {j}), got {matrix[i, j]}"
-
-    def test_missing_nexus_handled(self, capsys):
-        """Test that missing nexus IDs are handled gracefully."""
-        fp = gpd.GeoDataFrame({"toid": ["nex-missing"]}, index=["wb-1"])
-        network = gpd.GeoDataFrame({"toid": []}, index=[])
-        fp.index.name = "id"
-        network.index.name = "id"
-
-        matrix, ts_order = create_matrix(fp, network)
-
-        # Should capture the print statement about terminal nex
-        captured = capsys.readouterr()
-        assert "Terminal nex???" in captured.out
+            assert matrix[j, i] == 1, f"Expected 1 at ({j}, {i}), got {matrix[j, i]}"
 
 
 @pytest.mark.parametrize(
@@ -253,17 +271,16 @@ class TestAdjanceyMatrix:
     ],
 )
 class TestMatrixToZarr:
-    """Test cases for the matrix_to_zarr function."""
+    """Test cases for the coo_to_zarr function."""
 
-    def test_matrix_to_zarr_basic(self, fp, network, ghost, request):
+    def test_coo_to_zarr_basic(self, fp, network, ghost, request):
         """Test basic zarr export functionality."""
         fp = request.getfixturevalue(fp)
         network = request.getfixturevalue(network)
-        matrix, ts_order = create_matrix(fp, network, ghost)
-
+        coo, ts_order = create_matrix(fp, network, ghost)
         with tempfile.TemporaryDirectory() as temp_dir:
             out_path = Path(temp_dir) / "test_adjacency.zarr"
-            matrix_to_zarr(matrix, ts_order, "test_matrix", out_path)
+            coo_to_zarr(coo, ts_order, out_path)
 
             # Check that zarr file was created
             assert out_path.exists()
@@ -271,46 +288,24 @@ class TestMatrixToZarr:
             # Check that zarr structure is correct
             store = zarr.storage.LocalStore(root=out_path)
             root = zarr.open_group(store=store)
-            assert "test_matrix" in root
 
-            gauge_root = root["test_matrix"]
-            assert "indices_0" in gauge_root
-            assert "indices_1" in gauge_root
-            assert "values" in gauge_root
-            assert "order" in gauge_root
-
-    def test_matrix_to_zarr_default_path(self, fp, network, ghost, request):
-        """Test zarr export with default path."""
-        fp = request.getfixturevalue(fp)
-        network = request.getfixturevalue(network)
-        matrix, ts_order = create_matrix(fp, network, ghost)
-
-        # Change to temp directory to avoid cluttering
-        with tempfile.TemporaryDirectory() as temp_dir:
-            original_cwd = Path.cwd()
-            try:
-                os.chdir(temp_dir)
-                matrix_to_zarr(matrix, ts_order, "test_matrix")
-
-                expected_path = Path(temp_dir) / "test_matrix_adjacency.zarr"
-                assert expected_path.exists()
-            finally:
-                os.chdir(original_cwd)
+            assert "indices_0" in root
+            assert "indices_1" in root
+            assert "values" in root
+            assert "order" in root
 
     def test_zarr_attributes(self, fp, network, ghost, request):
         """Test that zarr attributes are set correctly."""
         fp = request.getfixturevalue(fp)
         network = request.getfixturevalue(network)
-        matrix, ts_order = create_matrix(fp, network, ghost)
+        coo, ts_order = create_matrix(fp, network, ghost)
 
         with tempfile.TemporaryDirectory() as temp_dir:
             out_path = Path(temp_dir) / "test_adjacency.zarr"
-            matrix_to_zarr(matrix, ts_order, "test_matrix", out_path)
+            coo_to_zarr(coo, ts_order, out_path)
 
             store = zarr.storage.LocalStore(root=out_path)
             root = zarr.open_group(store=store)
-            gauge_root = root["test_matrix"]
-
-            assert gauge_root.attrs["format"] == "COO"
-            assert "shape" in gauge_root.attrs
-            assert "data_types" in gauge_root.attrs
+            assert root.attrs["format"] == "COO"
+            assert "shape" in root.attrs
+            assert "data_types" in root.attrs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ maintainers = [
 ]
 
 dependencies = [
+    "adbc-driver-sqlite==1.6.0",
     "geopandas==1.0.1",
     "hydra-core==1.3.2",
     "icechunk==0.2.15",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,12 @@ dependencies = [
 
 [project.optional-dependencies]
 tests = [
-    "pytest==8.3.5",
+    "pytest==8.4.1",
     "pytest-cov==6.1.1",
     "ruff==0.11.13",
 ]
 engine = [
-  "polars",
+  "polars==1.31.0",
   "pyarrow==20.0.0",
   "pyiceberg[sql-sqlite]==0.9.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ maintainers = [
 ]
 
 dependencies = [
-    "adbc-driver-sqlite==1.6.0",
     "geopandas==1.0.1",
     "hydra-core==1.3.2",
     "icechunk==0.2.15",
@@ -34,7 +33,6 @@ dependencies = [
     "pre-commit==4.2.0",
     "pydantic==2.11.5",
     "pykan==0.2.8",
-    "rustworkx==0.16.0",
     "scikit-learn==1.6.1",
     "scipy==1.15.3",
     "tqdm==4.67.1",
@@ -74,9 +72,11 @@ tests = [
     "nbstripout==0.8.1",
 ]
 engine = [
+  "adbc-driver-sqlite==1.6.0",
   "polars==1.31.0",
   "pyarrow==20.0.0",
   "pyiceberg[sql-sqlite]==0.9.1",
+  "rustworkx==0.16.0",
 ]
 cpu = [
   "torch==2.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pre-commit==4.2.0",
     "pydantic==2.11.5",
     "pykan==0.2.8",
+    "rustworkx==0.16.0",
     "scikit-learn==1.6.1",
     "scipy==1.15.3",
     "tqdm==4.67.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ tests = [
     "ruff==0.11.13",
 ]
 engine = [
+  "polars",
   "pyarrow==20.0.0",
   "pyiceberg[sql-sqlite]==0.9.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,15 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+tests = [
+    "pytest==8.3.5",
+    "pytest-cov==6.1.1",
+    "ruff==0.11.13",
+]
+engine = [
+  "pyarrow==20.0.0",
+  "pyiceberg[sql-sqlite]==0.9.1",
+]
 docs = [
   "mkdocs-material==9.6.14",
   "sympy==1.14.0"


### PR DESCRIPTION
## Issue Addressed

<!-- Give a brief ~1 sentence overview of the main addition proposed by this pull request.
-->

Since the previous adjacency matrix script was taking 15 hours, I made some improvements using pyiceberg / polars to improve performance.

## Description

- updated tests to use lazy frames
- added `build_warehouse.py` to build the pyiceberg warehouse
- updated `engine/README.md` to contain new build steps
- updated `.pyproject.toml`, `.pre-commit-config.yaml` and the `.github/` linting to be all using the same formatting
- removed `name` from the args in adjacency. My current thoughts are to have a zarr COO matrix for just the hydrofabric, and then a zarr group full of COO matrices for all known subsets from gauges

<!-- Describe how you addressed the bug/feature request, what choices you made and why. Changes can be listed as bullet point;

-->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code cleanup/refactor
- [ ] Documentation update

Other (please specify):

## Checklist

- [X] Branch is up to date with master
- [X] Updated tests or added new tests
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [X] Code follows established style and conventions

# Tests
This code was run on an M1 Mac mini with 8GB of RAM
```sh
(ddr) *[iceberg][~/projects/forks/taddyb/ddr]$ python engine/adjacency.py ~/data/conus_nextgen.gpkg data/conus_adjacency.zarr
finding indices: 100%|█████████████████████████████| 828288/828288 [00:01<00:00, 490315.84it/s]
ordering matrix: 100%|█████████████████████████████| 828289/828289 [00:01<00:00, 794559.97it/s]
CONUS Hydrofabric adjacency written to zarr at data/conus_adjacency.zarr
```

```sh
(ddr) *[iceberg][~/projects/forks/taddyb/ddr]$ pytest engine/tests 
===================================== test session starts =====================================
platform darwin -- Python 3.12.8, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/taddbindas/projects/forks/taddyb/ddr
configfile: pyproject.toml
plugins: hydra-core-1.3.2
collected 19 items                                                                            

engine/tests/test_adjacency.py ...................                                      [100%]

====================================== warnings summary =======================================
.venv/lib/python3.12/site-packages/geopandas/_compat.py:7
  /Users/taddbindas/projects/forks/taddyb/ddr/.venv/lib/python3.12/site-packages/geopandas/_compat.py:7: DeprecationWarning: The 'shapely.geos' module is deprecated, and will be removed in a future version. All attributes of 'shapely.geos' are available directly from the top-level 'shapely' namespace (since shapely 2.0.0).
    import shapely.geos

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================ 19 passed, 1 warning in 1.22s ================================
```

closes #22
