### PR TITLE
fix: both min and max should be tensors for clamp)

### DIFF
--- a/src/ddr/routing/dmc.py
+++ b/src/ddr/routing/dmc.py
@@ -59,7 +59,7 @@ def _get_trapezoid_velocity(
     R = area / wetted_p
 
     v = torch.div(1, _n) * torch.pow(R, (2 / 3)) * torch.pow(_s0, (1 / 2))
-    c_ = torch.clamp(v, min=velocity_lb, max=15)
+    c_ = torch.clamp(v, min=velocity_lb, max=torch.tensor(15.0, device=v.device))
     c = c_ * 5 / 3
     return c
 


### PR DESCRIPTION
## Issue Addressed
Type issue in the clamp function.

## Description

The min argument is a Tensor but the max is a scalar int and pytorch doesn't always like it...

Simple fix is to initialize the max value as a scalar Tensor.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [ ] Documentation update

Other (please specify):

## Checklist

- [x] Branch is up to date with master
- [x] Updated tests or added new tests
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [x] Code follows established style and conventions
