### PR TITLE
Patch: solved streamflow dups in list when making combined matrices

### DIFF
--- a/src/ddr/dataset/forward_eval_dataset.py
+++ b/src/ddr/dataset/forward_eval_dataset.py
@@ -116,7 +116,9 @@ class forward_eval_dataset(TorchDataset):
                 ]
             )
             == np.array([_id.split("-")[1] for _id in gage_wb])
-        ).all(), "Gage WB don't match up with indices"
+        ).all(), (
+            "Gage WB don't match up with indices. There is something wrong with your batching and how it's loading in sparse matrices from the engine"
+        )
 
         # Create PyTorch sparse tensor with compressed 135x135 matrix
         adjacency_matrix = torch.sparse_csr_tensor(

--- a/src/ddr/dataset/train_dataset.py
+++ b/src/ddr/dataset/train_dataset.py
@@ -132,7 +132,9 @@ class train_dataset(TorchDataset):
                 ]
             )
             == np.array([_id.split("-")[1] for _id in gage_wb])
-        ).all(), "Gage WB don't match up with indices"
+        ).all(), (
+            "Gage WB don't match up with indices. There is something wrong with your batching and how it's loading in sparse matrices from the engine"
+        )
 
         # Create PyTorch sparse tensor with compressed 135x135 matrix
         adjacency_matrix = torch.sparse_csr_tensor(


### PR DESCRIPTION
## Issue Addressed

<!-- Give a brief ~1 sentence overview of the main addition proposed by this pull request.
-->

There was a bug when training a routing model with many gauges where some of the gauges were overlapping (dup IDs). Changing the list extension to a set of coordinate pairs in solved this bug. I ran into this using the following gauge.csv file

```csv
STAID,HUC02,DRAIN_SQKM,LAT_GAGE,LNG_GAGE,COMID,edge_intersection,zone_edge_id,zone_edge_uparea,zone_edge_vs_gage_area_difference,drainage_area_percent_error,a_merit_a_usgs_ratio
1015800,01,2313.755,46.523003,-68.371764,72040358,72040358_1,233192,2315.255194334315,1.5001943343149833,0.0006483808070927,[0.99861857 1.00064838 1.00267819 1.004708  ]
1017000,01,4278.907,46.777294,-68.157194,72040306,72040306_0,241126,4278.016696321501,0.8903036784995493,0.0002080680132799,[0.99979193 1.00308127 1.00637061 1.00965995]
```

This is the broken version
<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/d2c66c2d-6db2-48d3-aed4-0794dab8ac00" />

## Description

Fixes # (issue number)

<!-- Describe how you addressed the bug/feature request, what choices you made and why. Changes can be listed as bullet point;

- ...
- ...

-->

- using `set()` of `(r,c)` coordinates when making a large coo adjacency matrix instead of extending to a list

<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/ba234703-b860-4ce0-bad0-b0b77b3c42ab" />


The after effects of the change.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [ ] Documentation update

Other (please specify):

## Checklist

- [X] Branch is up to date with master
- [ ] Updated tests or added new tests
- [X] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [ ] Code follows established style and conventions
