### PR TITLE
solve the inconsistency when converting between torch and cupy

### DIFF
--- a/src/ddr/routing/utils.py
+++ b/src/ddr/routing/utils.py
@@ -517,13 +517,38 @@ def _compute_row_indices_gpu(crow_indices: torch.Tensor, nnz: int) -> torch.Tens
 
 
 def torch_to_cupy(t: torch.Tensor) -> cp.ndarray:
+    """
+    Converts a torch tensor to the cupy using dlpack
+
+    Parameters
+    ----------
+    t: torch.Tensor
+        the input tensor
+
+    Returns
+    -------
+    cp.ndarray
+        The same input tensor moved to a CUPY array
+    """
     assert t.is_cuda, "Expect a CUDA tensor"
     t = t.contiguous()  # ensure C-contiguous layout
     with cp.cuda.Device(t.device.index):
         return cp.from_dlpack(torch.utils.dlpack.to_dlpack(t))
 
 def cupy_to_torch(a: cp.ndarray) -> torch.Tensor:
-    # returns a CUDA tensor sharing memory with `a`
+    """
+    Returns a CUDA tensor sharing memory with `a`
+
+    Parameters
+    ----------
+    a: cp.ndarray
+        the input cupy array
+
+    Returns
+    -------
+    torch.Tensor
+        The output pytorch tensor
+    """
     return torch.utils.dlpack.from_dlpack(a)
 
 


### PR DESCRIPTION
## Issue Addressed

<!-- Give a brief ~1 sentence overview of the main addition proposed by this pull request.
-->

Uses a built in function to convert tensor to cupy and back to tensor as there were issues with the existing structure

## Description

Fixes # (issue number)

<!-- Describe how you addressed the bug/feature request, what choices you made and why. Changes can be listed as bullet point;

- ...
- ...

-->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [ ] Documentation update

Other (please specify):

## Checklist

- [ ] Branch is up to date with master
- [ ] Updated tests or added new tests
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [ ] Code follows established style and conventions
