### PR TITLE
Patch: fixed dtype mismatches

### DIFF
--- a/src/ddr/routing/utils.py
+++ b/src/ddr/routing/utils.py
@@ -535,6 +535,7 @@ def torch_to_cupy(t: torch.Tensor) -> cp.ndarray:
     with cp.cuda.Device(t.device.index):
         return cp.from_dlpack(torch.utils.dlpack.to_dlpack(t))
 
+
 def cupy_to_torch(a: cp.ndarray) -> torch.Tensor:
     """
     Returns a CUDA tensor sharing memory with `a`

--- a/src/ddr/routing/utils.py
+++ b/src/ddr/routing/utils.py
@@ -516,7 +516,7 @@ def _compute_row_indices_gpu(crow_indices: torch.Tensor, nnz: int) -> torch.Tens
     return row_indices
 
 
-def torch_to_cupy(t: torch.Tensor) -> cp.ndarray:
+def torch_to_cupy(t: torch.Tensor) -> "cp.ndarray":
     """
     Converts a torch tensor to the cupy using dlpack
 
@@ -536,7 +536,7 @@ def torch_to_cupy(t: torch.Tensor) -> cp.ndarray:
         return cp.from_dlpack(torch.utils.dlpack.to_dlpack(t))
 
 
-def cupy_to_torch(a: cp.ndarray) -> torch.Tensor:
+def cupy_to_torch(a: "cp.ndarray") -> torch.Tensor:
     """
     Returns a CUDA tensor sharing memory with `a`
 

--- a/src/ddr/routing/utils.py
+++ b/src/ddr/routing/utils.py
@@ -346,9 +346,7 @@ def _backward_gpu(
             A_T_cp, grad_output_cp, lower=transposed_lower, unit_diagonal=unit_diagonal
         )
 
-        # Convert back to PyTorch
-        pytorch_device = A_values.device if A_values.is_cuda else grad_output.device
-        return cupy_to_torch(gradb_cp, device=pytorch_device)
+        return cupy_to_torch(gradb_cp)
 
     # NOTE: Uncomment if we get to an exception one day
     # except Exception as e:

--- a/src/ddr/routing/utils.py
+++ b/src/ddr/routing/utils.py
@@ -643,16 +643,17 @@ class TriangularSparseSolver(torch.autograd.Function):
             try:
                 cuda_device = cp.cuda.Device(device)
                 with cuda_device:
-                    data_cp = torch_to_cupy(A_values)
-                    indices_cp = torch_to_cupy(col_indices)
-                    indptr_cp = torch_to_cupy(crow_indices)
-                    b_cp = torch_to_cupy(b)
+                    data_cp = torch_to_cupy(A_values).astype(cp.float32)
+                    indices_cp = torch_to_cupy(col_indices).astype(cp.int32)
+                    indptr_cp = torch_to_cupy(crow_indices).astype(cp.int32)
+                    b_cp = torch_to_cupy(b).astype(cp.float32)
                     A_cp = cp_csr_matrix((data_cp, indices_cp, indptr_cp), shape=(n, n))
 
-                    x_cp = cp_spsolve_triangular(A_cp, b_cp, lower=lower, unit_diagonal=unit_diagonal)
+                    x_cp = cp_spsolve_triangular(A_cp, b_cp, lower=lower, unit_diagonal=unit_diagonal).astype(
+                        cp.float32
+                    )
 
-                    pytorch_device = A_values.device if A_values.is_cuda else b.device
-                    x = cupy_to_torch(x_cp, device=pytorch_device)
+                    x = cupy_to_torch(x_cp)
 
             except ValueError as e:
                 log.error(f"GPU triangular sparse solve failed: {e}")


### PR DESCRIPTION
## Issue Addressed

<!-- Give a brief ~1 sentence overview of the main addition proposed by this pull request.
-->

When running test cases there was a dtype mismatch when using the Cupy triangular solver. This fix addresses a float 32 -> 64 conversion. Could be done better in the future, but casting works for now.

## Description

Fixes # (issue number)

<!-- Describe how you addressed the bug/feature request, what choices you made and why. Changes can be listed as bullet point;

- ...
- ...

-->

Code results from training
```py
[2025-08-27 18:18:28,029][ddr.dataset.streamflow][INFO] - cat-1560822 missing from the streamflow dataset
Running dMC Routing for Epoch: 1 | Mini Batch: 0 | : 100%|############################################| 8735/8735 [00:54<00:00, 160.66it/s]
[2025-08-27 18:19:23,306][__main__][INFO] - Running backpropagation
/projects/mhpi/tbindas/ddr/src/ddr/validation/metrics.py:202: RuntimeWarning: divide by zero encountered in scalar divide
  p_bias = np.sum(pred - target) / np.sum(target) * 100
[2025-08-27 18:20:42,898][ddr.validation.utils][INFO] - ----------------------------------------
[2025-08-27 18:20:42,898][ddr.validation.utils][INFO] - Epoch: 1         | Mini Batch: 0        
[2025-08-27 18:20:42,898][ddr.validation.utils][INFO] - ----------------------------------------
[2025-08-27 18:20:42,898][ddr.validation.utils][INFO] - Metric     |         Mean |       Median
[2025-08-27 18:20:42,898][ddr.validation.utils][INFO] - ----------------------------------------
[2025-08-27 18:20:42,898][ddr.validation.utils][INFO] - NSE        |      -3.2109 |       0.5583
[2025-08-27 18:20:42,898][ddr.validation.utils][INFO] - RMSE       |      16.0615 |       6.8283
[2025-08-27 18:20:42,898][ddr.validation.utils][INFO] - KGE        |       0.2628 |       0.6230
[2025-08-27 18:20:42,899][ddr.validation.utils][INFO] - ----------------------------------------
[2025-08-27 18:20:42,899][__main__][INFO] - Loss: 1025.6202392578125
[2025-08-27 18:20:42,899][__main__][INFO] - Median Mannings Roughness: 0.18358397483825684
.
.
.
Running dMC Routing for Epoch: 1 | Mini Batch: 1 | : 100%|############################################| 8735/8735 [00:51<00:00, 170.84it/s]
[2025-08-27 18:21:36,894][__main__][INFO] - Running backpropagation
[2025-08-27 18:22:56,794][ddr.validation.utils][INFO] - ----------------------------------------
[2025-08-27 18:22:56,794][ddr.validation.utils][INFO] - Epoch: 1         | Mini Batch: 1        
[2025-08-27 18:22:56,794][ddr.validation.utils][INFO] - ----------------------------------------
[2025-08-27 18:22:56,794][ddr.validation.utils][INFO] - Metric     |         Mean |       Median
[2025-08-27 18:22:56,794][ddr.validation.utils][INFO] - ----------------------------------------
[2025-08-27 18:22:56,794][ddr.validation.utils][INFO] - NSE        |      -0.3849 |       0.7384
[2025-08-27 18:22:56,795][ddr.validation.utils][INFO] - RMSE       |      18.7452 |       6.6245
[2025-08-27 18:22:56,795][ddr.validation.utils][INFO] - KGE        |       0.6674 |       0.7184
[2025-08-27 18:22:56,795][ddr.validation.utils][INFO] - ----------------------------------------
[2025-08-27 18:22:56,795][__main__][INFO] - Loss: 1682.6221923828125
[2025-08-27 18:22:56,795][__main__][INFO] - Median Mannings Roughness: 0.1771397888660431
...
```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [ ] Documentation update

Other (please specify):

## Checklist

- [ ] Branch is up to date with master
- [ ] Updated tests or added new tests
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [ ] Code follows established style and conventions
