### PR TITLE
patch: fixing error with saving MERIT adjacency matrices in engine

### DIFF
--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -3,7 +3,9 @@ defaults:
   - _self_
   - hydra: settings
 
-name: DDR-v${oc.env:DDR_VERSION,dev}
+mode: training
+geodataset: lynker_hydrofabric
+name: ddr-v${oc.env:DDR_VERSION,dev}-${geodataset}-${mode}
 
 data_sources:
   hydrofabric_gpkg: "DOWNLOAD THE FILE FROM https://www.lynker-spatial.com/data/hydrofabric/v2.2/conus/"  # patched

--- a/docs/engine/index.md
+++ b/docs/engine/index.md
@@ -28,13 +28,18 @@ which will install the `ddr-engine` package
 
 ## Examples:
 
+NOTE: by default:
+- `--path` will be set to `data/`
+- `--gages` will be set to `datasets/gage_info/dhbv2_gages.csv`
+
+
 ### CONUS v2.2 Hydrofabric
 
 !!! warning
     Dataset is not included in the repo and needs to be downloaded
 
 ```sh
-uv run python engine/scripts/build_hydrofabric_v2.2_matrices.py <PATH/TO/conus_nextgen.gpkg> data/ --gages datasets/mhpi/dHBV2.0UH/training_gauges.csv
+uv run python engine/scripts/build_hydrofabric_v2.2_matrices.py <PATH/TO/conus_nextgen.gpkg>
 ```
 
 ### MERIT Flowlines
@@ -43,5 +48,5 @@ uv run python engine/scripts/build_hydrofabric_v2.2_matrices.py <PATH/TO/conus_n
     Dataset is not included in the repo and can be downloded from the [following location](https://drive.google.com/drive/folders/1DhLXCdMYVkRtlgHBHkiFmpPjTQJX5k1g?usp=sharing)
 
 ```sh
-uv run python engine/scripts/build_merit_matrices.py <PATH/TO/riv_pfaf_7_MERIT_Hydro_v07_Basins_v01_bugfix1.shp> data/ --gages datasets/mhpi/dHBV2.0UH/training_gauges.csv
+uv run python engine/scripts/build_merit_matrices.py <PATH/TO/riv_pfaf_7_MERIT_Hydro_v07_Basins_v01_bugfix1.shp>
 ```

--- a/engine/scripts/build_hydrofabric_v2.2_matrices.py
+++ b/engine/scripts/build_hydrofabric_v2.2_matrices.py
@@ -30,18 +30,16 @@ if __name__ == "__main__":
         help="Path to the hydrofabric geopackage.",
     )
     parser.add_argument(
-        "path",
-        nargs="?",
+        "--path",
         type=Path,
-        default=None,
+        default="data/",
         help="Path to save the zarr group. Defaults to current working directory with name appended.",
     )
 
     parser.add_argument(
         "--gages",
         type=Path,
-        required=False,
-        default=None,
+        default=Path("datasets/gage_info/dhbv2_gages.csv"),
         help="The gauges CSV file containing the training locations. Only needed if gage adjacency matrices are being made.",
     )
     args = parser.parse_args()

--- a/engine/scripts/build_merit_matrices.py
+++ b/engine/scripts/build_merit_matrices.py
@@ -27,22 +27,19 @@ if __name__ == "__main__":
     parser.add_argument(
         "--pkg",
         type=Path,
-        required=False,
         default="/projects/mhpi/data/MERIT/raw/continent/riv_pfaf_7_MERIT_Hydro_v07_Basins_v01_bugfix1.shp",
         help="Path to the MERIT shapefile.",
     )
     parser.add_argument(
         "--path",
         type=Path,
-        default="/projects/mhpi/tbindas/ddr/data/tmp/",
-        required=False,
+        default="data/",
         help="Path to save the zarr group. Defaults to current working directory",
     )
     parser.add_argument(
         "--gages",
         type=Path,
-        required=False,
-        default="/projects/mhpi/tbindas/datasets/mhpi/dHBV2.0UH/training_gauges.csv",
+        default=Path("datasets/gage_info/dhbv2_gages.csv"),
         help="The gauges CSV file containing the training locations with COMID column.",
     )
     args = parser.parse_args()
@@ -90,8 +87,8 @@ if __name__ == "__main__":
         merit_mapping = {comid: idx for idx, comid in enumerate(ts_order)}
 
         # Create local zarr store
-        store = zarr.storage.LocalStore(root=out_path)
-        if out_path.exists():
+        store = zarr.storage.LocalStore(root=gages_out_path)
+        if gages_out_path.exists():
             root = zarr.open_group(store=store)
         else:
             root = zarr.create_group(store=store)
@@ -137,4 +134,4 @@ if __name__ == "__main__":
                 merit_mapping=merit_mapping,
             )
 
-        print(f"MERIT Gauge adjacency matrices written to {out_path}")
+        print(f"MERIT Gauge adjacency matrices written to {gages_out_path}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "hydra-core",
   "icechunk",
   "matplotlib",
-  "numpy",
+  "numpy>=2.4.1",
   "pandas",
   "pydantic",
   "pykan",


### PR DESCRIPTION
## Issue Addressed

I noticed the path to which gages were written from the `engine/` merit script was to the same group the adjacency matrix was from. This is wrong, and the gages should be in their own group 

## Description

- changes `out_path` to `gages_out_path` 
- makes `data/` the default save location for both scripts
- makes `datasets/gage_info/dhbv2_gages.csv` the default path for training gages

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [X] Documentation update

Other (please specify):

## Checklist

- [X] Branch is up to date with master
- [ ] Updated tests or added new tests
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [X] Code follows established style and conventions
