### PR TITLE
LogNorm addition for `top_width` and `side_slope`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ config/
 
 # eval example data
 examples/eval/*.zarr
+
+# scratch notebooks
+examples/scratch

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -6,37 +6,36 @@ defaults:
 mode: training
 geodataset: lynker_hydrofabric
 name: ddr-v${oc.env:DDR_VERSION,dev}-${geodataset}-${mode}
-
-data_sources:
-  hydrofabric_gpkg: "DOWNLOAD THE FILE FROM https://www.lynker-spatial.com/data/hydrofabric/v2.2/conus/"  # patched
-  conus_adjacency: ./../data/conus_adjacency.zarr
-  gages_adjacency: ./../data/gages_adjacency.zarr
-  statistics: ./../data/
-  gages: "DOWNLOAD THE FILE FROM https://github.com/DeepGroundwater/datasets/blob/master/mhpi/dHBV2.0UH/training_gauges.csv"
-
-params:
-  attribute_minimums:
-    discharge: 0.0001
-    slope: 0.0001
-    velocity: 0.01
-    depth: 0.01
-    bottom_width: 0.01
-  parameter_ranges:
-    'n':
-    - 0.01
-    - 0.35
-    q_spatial:
-    - 0.0
-    - 3.0
-  defaults:
-    p: 21
-  tau: 3
-  save_path: ./
-
 np_seed: 1
 seed: 0
-device: 0
+device: 7
 s3_region: us-east-2
+
+data_sources:
+  attributes: /projects/mhpi/data/icechunk/hydrofabric_v2.2_attributes
+  geospatial_fabric_gpkg: "DOWNLOAD THE FILE FROM https://www.lynker-spatial.com/data/hydrofabric/v2.2/conus/"
+  conus_adjacency: ./../data/hydrofabric_v2.2_conus_adjacency.zarr
+  gages_adjacency: ./../data/hydrofabric_v2.2_gages_conus_adjacency.zarr
+  statistics: ./../data/statistics
+  streamflow: /path/to/icechunk/hydrofabric_v2.2_dhbv_retrospective
+  observations: /path/to/icechunk/usgs/observations
+  gages: ./../streamflow_datasets/gage_info/dhbv2_gages.csv
+
+params:
+  save_path: ./
+
+experiment:
+  batch_size: 64
+  start_time: 1981/10/01
+  end_time: 1995/09/30
+  epochs: 5
+  learning_rate: {
+      1: 0.005,
+      3: 0.001
+  }
+  rho: 365
+  shuffle: true
+  warmup: 3
 
 kan:
   hidden_size: 11

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -2,18 +2,316 @@
 icon: lucide/database
 ---
 
-# streamflow_datasets/Specifications
+# Streamflow Datasets & Specifications
 
-DDR is meant to route a large number of unit-catchments across many timesteps. Therefore, a uniform input specification was developed in order to accomidate the highest number of streamflow inputs.
+DDR is designed to route lateral inflow from a large number of unit-catchments across many timesteps. To accommodate diverse data sources, DDR uses a uniform input specification.
 
-To get a list of gauges to train your model on, please see the https://github.com/DeepGroundwater/datasets repo.
+## Overview
 
-## Lateral Inflow Spec
+DDR requires three main types of input data:
+
+1. **Lateral Inflow** (Q' or Q_l): Runoff predictions from unit catchments
+2. **Geospatial Fabric**: River network topology and channel properties
+3. **Observations**: Streamflow measurements for training/validation
+
+## Lateral Inflow Specification
+
+### Data Format
+
+Lateral inflow data should be provided as an [Icechunk](https://icechunk.io/) store or zarr array with the following structure:
+
+```python
+import xarray as xr
+
+# Expected dimensions and coordinates
+ds = xr.Dataset(
+    data_vars={
+        "Qr": (["time", "divide_id"], qr_data),  # Lateral inflow in m³/s
+    },
+    coords={
+        "time": time_index,           # Daily timestamps
+        "divide_id": divide_ids,      # Catchment identifiers
+    },
+    attrs={
+        "units": "m^3/s",
+        "source": "your_model_name",
+    }
+)
+```
+
+### Requirements
+
+| Property | Requirement |
+|----------|-------------|
+| Units | Cubic meters per second (m³/s) |
+| Temporal resolution | Daily (interpolated to hourly internally) |
+| Spatial coverage | All divide_ids in the routing domain |
+| Missing values | Fill with small positive value (e.g., 1e-6) |
+| Negative values | Not allowed |
+
+### Unit Conversion
+
+If your data is in mm/day, convert using drainage area:
+
+```python
+# Convert mm/day to m³/s
+# mm/day * km² * 1000 / 86400 = m³/s
+conversion_factor = area_km2 * 1000 / 86400
+qr_m3_s = runoff_mm_day * conversion_factor
+```
+
+### Supported Data Sources
+
+DDR provides download scripts for several pre-computed lateral inflow products:
+
+| Source | Coverage | Period | Location |
+|--------|----------|--------|----------|
+| dHBV2.0 (Hydrofabric v2.2) | CONUS | 1980-2020 | `s3://mhpi-spatial/hydrofabric_v2.2_dhbv_retrospective` |
+| dHBV2.0 (MERIT) | CONUS | 1980-2020 | [Zenodo](https://zenodo.org/records/15784945) |
 
 ## Geospatial Data Requirements
 
-### Attributes
+### Hydrofabric v2.2
 
-### Connectivity
+The NOAA-OWP Hydrofabric v2.2 is the recommended geospatial dataset for CONUS applications.
+
+**Required Layers:**
+
+| Layer | Description |
+|-------|-------------|
+| `flowpaths` | River reaches with topology (id, toid) |
+| `flowpath-attributes-ml` | Channel properties (length, slope, width) |
+| `network` | Network connectivity including gauge locations |
+
+**Required Attributes:**
+
+```python
+# Flowpath attributes
+flowpath_attrs = [
+    "id",              # Waterbody identifier (wb-XXXXX)
+    "toid",            # Downstream identifier
+    "Length_m",        # Channel length in meters
+    "So",              # Channel slope (dimensionless)
+    "TopWdth",         # Top width in meters
+    "ChSlp",           # Channel side slope
+    "MusX",            # Muskingum X parameter
+]
+```
+
+### MERIT Hydro
+
+MERIT Hydro provides global coverage with variable resolution.
+
+**Required Attributes:**
+
+| Attribute | Description |
+|-----------|-------------|
+| `COMID` | Unique catchment identifier |
+| `NextDownID` | Downstream COMID |
+| `up1`-`up4` | Upstream COMID connections |
+| `lengthkm` | Channel length in kilometers |
+| `slope` | Channel slope |
+| `unitarea` | Catchment area in km² |
+
+### Connectivity Format
+
+DDR uses sparse COO (Coordinate) matrices to represent river network connectivity:
+
+```python
+# Adjacency matrix structure
+# Rows: downstream segments
+# Columns: upstream segments
+# Values: 1 (connected) or 0 (not connected)
+
+# Lower triangular: ensures topological ordering
+# A[i, j] = 1 means flow goes from segment j to segment i
+```
+
+The engine scripts automatically create these matrices:
+
+```bash
+# Creates:
+# - hydrofabric_v2.2_conus_adjacency.zarr (full network)
+# - hydrofabric_v2.2_gages_conus_adjacency.zarr (per-gauge subsets)
+
+uv run python engine/scripts/build_hydrofabric_v2.2_matrices.py \
+    /path/to/conus_nextgen.gpkg data/
+```
+
+## Catchment Attributes
+
+The neural network requires catchment attributes to predict routing parameters.
+
+### Default Attribute Set (Hydrofabric v2.2)
+
+```yaml
+input_var_names:
+  - aridity               # Aridity index
+  - meanelevation         # Mean elevation (m)
+  - log_uparea            # Log10 of the upstream area for a catchment (m)
+  - meanP                 # Mean Annual Precipitation (mm)
+```
+
+These attributes can be either calculated by hand, or provided for you through `s3://mhpi-spatial/hydrofabric_v2.2_attributes/` for the lynker hydrofabric. Catchment attributes are geodataset specific
+
+### Attribute Storage
+
+Attributes should be stored in an Icechunk/zarr store if possible. NetCDF support is used in MERIT:
+
+```python
+# Hydrofabric v2.2 format
+ds = xr.Dataset(
+    data_vars={
+        "aridity": (["divide_id"], aridity_values),
+        "elev_mean": (["divide_id"], elev_values),
+        # ... other attributes
+    },
+    coords={
+        "divide_id": divide_ids,  # Format: "cat-XXXXX"
+    }
+)
+```
+
+### Normalization
+
+DDR automatically computes and caches normalization statistics:
+
+```python
+# Statistics stored per attribute
+{
+    "min": min_value,
+    "max": max_value,
+    "mean": mean_value,
+    "std": std_value,
+    "p10": 10th_percentile,
+    "p90": 90th_percentile,
+}
+```
+
+Statistics are cached to `data/statistics/{geodataset}_attribute_statistics_{store_name}.json`.
 
 ## Observations
+
+### USGS Streamflow Data
+
+DDR uses USGS streamflow observations for training and validation.
+
+**Data Format:**
+
+```python
+ds = xr.Dataset(
+    data_vars={
+        "streamflow": (["time", "gage_id"], flow_values),  # m³/s
+    },
+    coords={
+        "time": time_index,
+        "gage_id": gage_ids,  # 8-digit zero-padded strings
+    }
+)
+```
+
+**Pre-formatted Observations:**
+
+DDR provides access to pre-processed USGS data:
+
+```yaml
+observations: "s3://mhpi-spatial/usgs_streamflow_observations/"
+```
+
+### Gauge Information CSV
+
+Training requires a gauge information file:
+
+```csv
+STAID,STANAME,DRAIN_SQKM,LAT_GAGE,LNG_GAGE
+01563500,Susquehanna River at Harrisburg,62419,40.2548,-76.8867
+01570500,Susquehanna River at Sunbury,46706,40.8576,-76.7944
+```
+
+**Required Columns:**
+
+| Column | Description | Format |
+|--------|-------------|--------|
+| `STAID` | Station ID | 8-digit, zero-padded |
+| `DRAIN_SQKM` | Drainage area | km² (positive float) |
+| `LAT_GAGE` | Latitude | Decimal degrees |
+| `LNG_GAGE` | Longitude | Decimal degrees |
+
+**Optional Columns:**
+
+| Column | Description |
+|--------|-------------|
+| `STANAME` | Station name |
+| `COMID` | MERIT catchment ID (required for MERIT dataset) |
+
+You can find pre-prepared gauge lists in the [streamflow_datasets repository](https://github.com/DeepGroundwater/datasets).
+
+## Data Sources
+
+### Pre-computed S3 Data
+
+DDR provides access to pre-computed datasets on AWS S3:
+
+| Dataset | S3 Path | Description |
+|---------|---------|-------------|
+| HF v2.2 Attributes | `s3://mhpi-spatial/hydrofabric_v2.2_attributes/` | Catchment attributes |
+| HF v2.2 Streamflow | `s3://mhpi-spatial/hydrofabric_v2.2_dhbv_retrospective` | dHBV2.0 predictions |
+| USGS Observations | `s3://mhpi-spatial/usgs_streamflow_observations/` | Historical streamflow |
+
+Access is anonymous (no AWS credentials required):
+
+```python
+from ddr.io.readers import read_ic
+
+# Read from S3
+ds = read_ic("s3://mhpi-spatial/hydrofabric_v2.2_attributes/", region="us-east-2")
+```
+
+### Local Data
+
+For local data, use file paths:
+
+```yaml
+data_sources:
+  attributes: "/path/to/local/attributes/"
+  streamflow: "/path/to/local/streamflow/"
+```
+
+## Preparing Custom Data
+
+### Creating Lateral Inflow Data
+
+If you have your own runoff model, format the output for DDR:
+
+```python
+import icechunk as ic
+import xarray as xr
+from icechunk.xarray import to_icechunk
+
+# Load your model output
+qr = load_your_model_output()  # shape: (n_catchments, n_timesteps)
+
+# Create xarray Dataset
+ds = xr.Dataset(
+    data_vars={
+        "Qr": (["divide_id", "time"], qr.astype(np.float32)),
+    },
+    coords={
+        "divide_id": your_divide_ids,
+        "time": pd.date_range("1980-01-01", periods=n_timesteps, freq="D"),
+    },
+    attrs={"units": "m^3/s"},
+)
+
+# Save to Icechunk
+storage = ic.local_filesystem_storage("./my_streamflow_data")
+repo = ic.Repository.create(storage)
+session = repo.writable_session("main")
+to_icechunk(ds, session)
+session.commit("Initial commit")
+```
+
+## External Resources
+
+- **Gauge Lists**: [DeepGroundwater/datasets](https://github.com/DeepGroundwater/ddr/streamflow_datasets/gage_info/dhbv2_gages.csv)
+- **MERIT Hydro**: [University of Tokyo](http://hydro.iis.u-tokyo.ac.jp/~yamadai/MERIT_Hydro/)

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -4,4 +4,112 @@ icon: lucide/gpu
 
 # GPU Routing
 
-## Sparse Matrices
+DDR is optimized for GPU acceleration using sparse matrix operations. This guide explains how GPU routing works and how to optimize performance.
+
+## Overview
+
+DDR's routing algorithm involves solving sparse triangular linear systems at each timestep. GPU acceleration provides significant speedups for large networks
+
+## Requirements
+
+### Hardware
+
+- NVIDIA GPU with CUDA support (Compute Capability 6.0+)
+- Recommended: 8GB+ VRAM for CONUS-scale routing
+
+### Software
+
+```bash
+# Install with GPU support
+uv sync --all-packages --extra cu124
+```
+
+This installs:
+
+- **PyTorch** with CUDA 12.4 support
+- **CuPy**: GPU-accelerated NumPy/SciPy
+- **cupyx.scipy.sparse**: GPU sparse matrix operations
+
+## Sparse Matrix Implementation
+
+### Why Sparse Matrices?
+
+River networks are naturally sparse - each segment connects to at most a few upstream segments. Using dense matrices would be computationally infeasible
+
+### COO Format
+
+DDR stores adjacency matrices in Coordinate (COO) format, which efficiently represents sparse data:
+
+```python
+# COO representation
+row_indices = [1, 2, 3, 3]      # Downstream segment indices
+col_indices = [0, 1, 1, 2]      # Upstream segment indices
+values = [1, 1, 1, 1]           # Connection weights (always 1)
+shape = (n_segments, n_segments)
+
+# Matrix interpretation:
+# Flow from segment 0 → segment 1
+# Flow from segment 1 → segment 2
+# Flow from segment 1 → segment 3
+# Flow from segment 2 → segment 3
+```
+
+### Lower Triangular Structure
+
+The adjacency matrix is always lower triangular after topological sorting:
+
+```
+     0  1  2  3
+0 [  0  0  0  0 ]  ← Headwater
+1 [  1  0  0  0 ]  ← Receives from 0
+2 [  0  1  0  0 ]  ← Receives from 1
+3 [  0  1  1  0 ]  ← Receives from 1 and 2
+```
+
+This structure enables efficient forward substitution during routing.
+
+## GPU Solver Architecture
+
+### Triangular Sparse Solve
+
+The core routing step solves: `A * Q_{t+1} = b`
+
+Where:
+- `A = I - C₁ * N` (identity minus scaled adjacency)
+- `b = C₂(N·Q_t) + C₃·Q_t + C₄·Q'` (right-hand side)
+- `C₁, C₂, C₃, C₄` = Muskingum-Cunge coefficients
+
+```python
+# GPU solver path (from ddr/routing/utils.py)
+def triangular_sparse_solve(A_values, crow_indices, col_indices, b, lower, unit_diagonal, device):
+    """Custom autograd function for sparse triangular solve."""
+
+    if device == "cpu":
+        # Use SciPy
+        A_scipy = sp.csr_matrix((data_np, col_np, crow_np), shape=(n, n))
+        x = spsolve_triangular(A_scipy, b_np, lower=lower)
+    else:
+        # Use CuPy (GPU)
+        A_cp = cp_csr_matrix((data_cp, indices_cp, indptr_cp), shape=(n, n))
+        x = cp_spsolve_triangular(A_cp, b_cp, lower=lower)
+
+    return x
+```
+
+### Gradient Computation
+
+DDR implements custom backward passes for sparse operations to allow autograd to work:
+
+```python
+# Backward pass (simplified)
+def backward(ctx, grad_output):
+    # Solve transposed system: A^T * gradb = grad_output
+    A_T = A.T
+    gradb = spsolve_triangular(A_T, grad_output, lower=not lower)
+
+    # Gradient for matrix values
+    # gradA_values = -gradb[rows] * x[cols]
+    return gradA_values, gradb
+```
+
+float32 precision is used to decrease computational memory requirements

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,98 @@
 # What is DDR?
 Distributed Differentiable Routing (DDR) is a end-to-end differentiable Muskingum Cunge flow router (`src/ddr`) + geospatial scaffolding/wrapper (`/engine`) for building graphs from geospatial fabrics. This work is brought to you by contributers/developers of the $\delta$MC, [$\delta$MC-Juniata-hydroDL2](https://github.com/mhpi/dMC-Juniata-hydroDL2), and [T-Route](https://github.com/NOAA-OWP/t-route). The goal of this project is to provide an open-sourced, easy to follow, routing module that can be applied to a wide variety of geospatial flow networks and input lateral flow datasets.
 
-[Get started](../index.md) or learn more about DDR:
+The goal of this project is to provide an open-sourced, easy to follow, routing module that can be applied to a wide variety of geospatial flow networks and input lateral flow datasets.
+
+## Why DDR?
+
+Traditional river routing models require manual calibration of parameters like Manning's roughness coefficient across thousands of river segments. DDR solves this by using **differentiable programming** - the routing equations are implemented in a way that allows automatic computation of gradients through the entire network, enabling neural networks to learn optimal parameters from observed streamflow data.
+
+### Key Features
+
+- **Differentiable Muskingum-Cunge Routing**: Physics-based routing with learnable parameters
+- **Neural Network Parameter Learning**: Uses Kolmogorov-Arnold Networks (KAN) to predict Manning's roughness and channel geometry from catchment attributes
+- **GPU Acceleration**: Sparse matrix operations optimized for both CPU and GPU
+- **Multiple Geospatial Datasets**: Support for NOAA-OWP Hydrofabric v2.2 and MERIT Hydro
+- **Scalable Architecture**: Route across thousands of river segments simultaneously
+
+## How It Works
+
+DDR combines physics-based river routing with machine learning:
+
+```
+Catchment Attributes → Neural Network → Physical Parameters → Muskingum-Cunge Routing → Streamflow
+        ↑                                                                                  ↓
+        └────────────────────── Gradient Backpropagation ──────────────────────────────────┘
+```
+
+1. **Input**: Lateral inflow predictions (Q') from unit catchments
+2. **Parameter Learning**: A neural network predicts Manning's roughness (n) and other parameters from catchment attributes
+3. **Routing**: The Muskingum-Cunge equations route flow downstream through the river network
+4. **Training**: Gradients flow backward through the entire system to optimize the neural network
 
 <div class="grid cards" markdown>
 
 - :fontawesome-solid-microchip: [__Model Training__](../usage/train.md) for how to create your own weights/states
 - :fontawesome-solid-laptop-code: [__Model Testing__](../usage/test.md) for evaluating your trained weights
 - :fontawesome-solid-terminal: [__Routing__](../usage/routing.md) for how to route flow anywhere with trained weights
-- :fontawesome-solid-gears: [__Summed Q_Prime__](../usage/train.md) for determining how well your unit catchment predictions are (pre-routing)
+- :fontawesome-solid-gears: [__Summed Q_Prime__](../usage/summed_q_prime.md) for determining how well your unit catchment predictions are (pre-routing)
 
 </div>
+
+## Supported Geospatial Datasets
+
+DDR currently supports two major hydrographic datasets:
+
+| Dataset | Coverage | Resolution | Status |
+|---------|----------|------------|--------|
+| [NOAA-OWP Hydrofabric v2.2](https://www.noaa.gov/organization/information-technology/noaa-hydrofabric) | CONUS | ~37 km² catchments | Fully supported |
+| [MERIT Hydro](http://hydro.iis.u-tokyo.ac.jp/~yamadai/MERIT_Hydro/) | Global | Variable | Fully supported |
+
+## Architecture Overview
+
+```
+ddr/
+├── src/ddr/                    # Core routing library
+│   ├── routing/                # Muskingum-Cunge implementation
+│   │   ├── mmc.py              # Core routing math
+│   │   ├── torch_mc.py         # PyTorch nn.Module wrapper
+│   │   └── utils.py            # Sparse solver utilities
+│   ├── nn/                     # Neural network modules
+│   │   └── kan.py              # Kolmogorov-Arnold Network
+│   ├── geodatazoo/             # Dataset classes
+│   │   ├── lynker_hydrofabric.py
+│   │   └── merit.py
+│   ├── io/                     # Data I/O utilities
+│   └── validation/             # Metrics and plotting
+├── engine/                     # Geospatial data preparation
+│   └── scripts/                # Matrix building scripts
+└── streamflow_datasets/        # Dataset download utilities
+```
+
+## Citation
+
+If you use DDR in your research, please cite:
+
+```bibtex
+@article{bindas2024improving,
+  author = {Bindas, Tadd and Tsai, Wen-Ping and Liu, Jiangtao and others},
+  title = {Improving River Routing Using a Differentiable Muskingum-Cunge Model and Physics-Informed Machine Learning},
+  journal = {Water Resources Research},
+  volume = {60},
+  number = {1},
+  year = {2024},
+  doi = {https://doi.org/10.1029/2023WR035337}
+}
+```
+
+A newer citation is in the works
+
+## Community
+
+- **GitHub Issues**: Report bugs and request features
+- **Discussions**: Ask questions and share ideas
+- **Contributing**: We welcome contributions! See our contributing guide.
+
+## License
+
+DDR is released under the Apache v2.0 License. See the [LICENSE](https://github.com/DeepGroundwater/ddr/blob/main/LICENSE) file for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,29 +7,6 @@ The goal of this project is to provide an open-sourced, easy to follow, routing 
 
 Traditional river routing models require manual calibration of parameters like Manning's roughness coefficient across thousands of river segments. DDR solves this by using **differentiable programming** - the routing equations are implemented in a way that allows automatic computation of gradients through the entire network, enabling neural networks to learn optimal parameters from observed streamflow data.
 
-### Key Features
-
-- **Differentiable Muskingum-Cunge Routing**: Physics-based routing with learnable parameters
-- **Neural Network Parameter Learning**: Uses Kolmogorov-Arnold Networks (KAN) to predict Manning's roughness and channel geometry from catchment attributes
-- **GPU Acceleration**: Sparse matrix operations optimized for both CPU and GPU
-- **Multiple Geospatial Datasets**: Support for NOAA-OWP Hydrofabric v2.2 and MERIT Hydro
-- **Scalable Architecture**: Route across thousands of river segments simultaneously
-
-## How It Works
-
-DDR combines physics-based river routing with machine learning:
-
-```
-Catchment Attributes → Neural Network → Physical Parameters → Muskingum-Cunge Routing → Streamflow
-        ↑                                                                                  ↓
-        └────────────────────── Gradient Backpropagation ──────────────────────────────────┘
-```
-
-1. **Input**: Lateral inflow predictions (Q') from unit catchments
-2. **Parameter Learning**: A neural network predicts Manning's roughness (n) and other parameters from catchment attributes
-3. **Routing**: The Muskingum-Cunge equations route flow downstream through the river network
-4. **Training**: Gradients flow backward through the entire system to optimize the neural network
-
 <div class="grid cards" markdown>
 
 - :fontawesome-solid-microchip: [__Model Training__](../usage/train.md) for how to create your own weights/states
@@ -38,6 +15,22 @@ Catchment Attributes → Neural Network → Physical Parameters → Muskingum-Cu
 - :fontawesome-solid-gears: [__Summed Q_Prime__](../usage/summed_q_prime.md) for determining how well your unit catchment predictions are (pre-routing)
 
 </div>
+
+
+## How It Works
+
+DDR combines physics-based river routing with machine learning:
+
+```
+Lumped Attributes → Neural Network → Physical Parameters → MC Routing → Runoff
+        ↑                                                                 ↓
+        └──────────────────── Gradient Backpropagation ───────────────────┘
+```
+
+1. **Input**: Lateral inflow predictions (Q') from unit catchments
+2. **Parameter Learning**: A neural network predicts Manning's roughness (n) and other parameters from catchment attributes
+3. **Routing**: The Muskingum-Cunge equations route flow downstream through the river network
+4. **Training**: Gradients flow backward through the entire system to optimize the neural network
 
 ## Supported Geospatial Datasets
 

--- a/docs/startup.md
+++ b/docs/startup.md
@@ -2,44 +2,228 @@
 icon: lucide/rocket
 ---
 
+---
+icon: lucide/rocket
+---
 
-# Getting started
+# Getting Started
 
-### Dependencies
+This guide will walk you through installing DDR and running your first routing experiment.
 
-The following commands will allow you to install all required dependencies for DDR
+## Prerequisites
 
-```sh
-# CPU
-uv sync --all-packages
-. .venv/bin/activate
+Before installing DDR, ensure you have:
 
-# or GPU
-uv sync --all-packages --extra cu124
-. .venv/bin/activate
+- **Python 3.11+**: DDR requires Python 3.11 or later
+- **uv**: The fast Python package manager ([install instructions](https://docs.astral.sh/uv/getting-started/installation/))
+- **Git**: For cloning the repository
+
+For GPU support (optional but recommended):
+- **CUDA 12.4+**: Required for GPU acceleration
+- **CuPy**: Will be installed automatically with GPU extras
+
+## Installation
+
+### Clone the Repository
+
+```bash
+git clone https://github.com/DeepGroundwater/ddr.git
+cd ddr
 ```
 
-### Data Engine
+### Install Dependencies
 
-Next, you need to create the necessary data files for running a routing across your domain.
-- The example below is for the NOAA-OWP Hydrofabric v2.2 (Dataset is not included in the repo)
-- This requires the `ddr-engine` local package to be installed (which is done automatically through the above `uv sync`)
-- The gauges.csv can be found [here](https://github.com/DeepGroundwater/streamflow_datasets/tree/master/mhpi/dHBV2.0UH)
+DDR uses `uv` for dependency management. Choose the appropriate installation based on your hardware:
 
-```sh
-uv run python engine/scripts/build_hydrofabric_v2.2_matrices.py <PATH/TO/conus_nextgen.gpkg> data/ --gages streamflow_datasets/mhpi/dHBV2.0UH/training_gauges.csv
+=== "CPU Only"
+
+    ```bash
+    uv sync --all-packages
+    ```
+
+=== "GPU (CUDA 12.4)"
+
+    ```bash
+    uv sync --all-packages --extra cu124
+    ```
+
+This installs both the main `ddr` package and the `ddr-engine` package for data preparation.
+
+### Verify Installation
+
+```python
+import ddr
+print(ddr.__version__)
 ```
 
-This will create two files used for routing
-- `hydrofabric_v2.2_conus_adjacency.zarr`
-  - a sparse COO matrix containing the whole river network for Hydrofabric v2.2 across CONUS
-- `hydrofabric_v2.2_gages_conus_adjacency.zarr`
-  - a zarr.Group of sparse coo matrices for river networks upstream of USGS Gauges
+## Data Preparation
 
-### Model Train
+Before training, you need to create the sparse adjacency matrices that define the river network topology.
 
-All that's left is to train a routing model
-```sh
-# Train a model using the MHPI S3 defaults
+### Step 1: Download Geospatial Data
+
+DDR requires a geospatial fabric defining the river network. Currently supported:
+
+**NOAA-OWP Hydrofabric v2.2** (Recommended for CONUS):
+
+- Download from Lynker-Spatial
+- File: `conus_nextgen.gpkg`
+
+**MERIT Hydro** (Global coverage):
+
+- Download from [MERIT Hydro website](http://hydro.iis.u-tokyo.ac.jp/~yamadai/MERIT_Hydro/)
+- Or use the [Google Drive mirror](https://drive.google.com/drive/folders/1DhLXCdMYVkRtlgHBHkiFmpPjTQJX5k1g?usp=sharing)
+
+### Step 2: Prepare Gauge Information
+
+Create a CSV file with gauge information. Required columns:
+
+| Column | Description | Example |
+|--------|-------------|---------|
+| `STAID` | USGS Station ID (7-8 digits, not zero padded) | `1563500` |
+| `DRAIN_SQKM` | Drainage area in km² | `2847.5` |
+| `LAT_GAGE` | Latitude of gauge | `40.2345` |
+| `LNG_GAGE` | Longitude of gauge | `-76.8901` |
+| `STANAME` | Station name (optional) | `Susquehanna River`
+
+__NOTE:__ to use MERIT you will need to have COMID also specified and mapped to each river gage
+
+You can find pre-prepared gauge lists in the [streamflow_datasets repository](https://github.com/DeepGroundwater/datasets).
+
+### Step 3: Build Adjacency Matrices
+
+Run the engine script to create the sparse network matrices:
+
+=== "Hydrofabric v2.2"
+
+    ```bash
+    uv run python engine/scripts/build_hydrofabric_v2.2_matrices.py \
+        <PATH/TO/conus_nextgen.gpkg> \
+        data/ \
+        --gages streamflow_datasets/mhpi/dHBV2.0UH/training_gauges.csv
+    ```
+
+=== "MERIT Hydro"
+
+    ```bash
+    uv run python engine/scripts/build_merit_matrices.py \
+        <PATH/TO/riv_pfaf_7_MERIT_Hydro_v07_Basins_v01_bugfix1.shp> \
+        data/ \
+        --gages your_gauges.csv
+    ```
+
+This creates two zarr stores:
+
+| File | Description |
+|------|-------------|
+| `*_conus_adjacency.zarr` | Full CONUS river network in sparse COO format |
+| `*_gages_conus_adjacency.zarr` | Per-gauge upstream subnetworks |
+
+These zarr stores are coo matrices stored using the [binsparse-python](https://github.com/ivirshup/binsparse-python) specification
+
+## Configuration
+
+DDR uses [Hydra](https://hydra.cc/) for configuration management. Configuration files are in YAML format.
+
+### Configuration Structure
+
+The most important part of your config is shown below. These are the data sources for DDR to work
+
+```yaml
+mode: training               # training, testing, or routing
+geodataset: lynker_hydrofabric  # the geodataset used to determine river connectivity
+name: ddr-v${oc.env:DDR_VERSION,dev}-${geodataset}-${mode}  # The name of the training run
+
+data_sources:
+  attributes: "s3://mhpi-spatial/hydrofabric_v2.2_attributes/"  # The path to your geodataset attributes
+  geospatial_fabric_gpkg: /path/to/conus_nextgen.gpkg  # the path to your geodataset for river connectivity
+  conus_adjacency: /path/to/hydrofabric_v2.2_conus_adjacency.zarr  # the output of engine/ using your geodataset
+  gages: /path/to/training_gages.csv  # the training gages used
+  gages_adjacency: /path/to/hydrofabric_v2.2_gages_conus_adjacency.zarr  # the output of engine/ using your geodataset for gage subgraph connectivity
+  streamflow: "s3://mhpi-spatial/hydrofabric_v2.2_dhbv_retrospective"  # the unit catchment streamflow prediction output you'll be using
+  observations: "s3://mhpi-spatial/usgs_streamflow_observations/"  # the USGS observations to train your model against
+  target_catchments:
+    - 1234   # the river ID for the catchment you want to route upstream of (MERIT EXAMPLE)
+    - wb-1234  # the river ID for the catchment you want to route upstream of (Lynker Hydrofabric EXAMPLE)
+```
+
+### Key Configuration Options
+
+#### Training
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `mode` | Operating mode: `training`, `testing`, `routing` | Required |
+| `geodataset` | Dataset type: `lynker_hydrofabric`, `merit` | Required |
+| `experiment.rho` | Time window length for training (days) | `None` (full period) |
+| `experiment.warmup` | Days excluded from loss calculation to allow the model to warm up | `3` |
+| `experiment.batch_size` | Number of gauges per batch | `1` |
+| `kan.hidden_size` | KAN hidden layer size (recommend 2n+1 where n=input features) | `21` |
+| `device` | GPU ID or `"cpu"` | `0` |
+
+#### Testing/Rouing (Inference)
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `mode` | Operating mode: `training`, `testing`, `routing` | Required |
+| `geodataset` | Dataset type: `lynker_hydrofabric`, `merit` | Required |
+| `experiment.warmup` | Days excluded from loss calculation to allow the model to warm up | `3` |
+| `experiment.batch_size` | Number of days included in the batch | `1` |
+| `kan.hidden_size` | KAN hidden layer size (recommend 2n+1 where n=input features) | `21` |
+| `device` | GPU ID or `"cpu"` | `0` |
+
+
+__NOTE:__ More geodataset support is coming soon
+
+## Running Your First Model
+
+### Quick Start
+
+```bash
+# Training
 python scripts/train.py --config-name example_config.yaml
+
+# Testing
+python scripts/test.py --config-name example_config.yaml
+
+# Routing a trained model over specified catchments / the whole dataset
+python scripts/router.py --config-name example_config.yaml
+
+# Checking the baseline unit catchment metrics
+python scripts/summed_q_prime.py --config-name example_config.yaml
 ```
+
+__NOTE:__ Please change the example config to match what mode/geodataset/method you need to work with. The config in the example is for structure only
+
+### Monitoring
+
+DDR logs progress including:
+
+- Loss values per epoch and mini-batch
+- NSE, RMSE, and KGE metrics
+- Parameter statistics
+
+Model checkpoints are saved to the `params.save_path` directory.
+
+### Expected Model outputs
+
+After running DDR, you'll have:
+
+```
+output/ddr-{version}-{geodataset}-{mode}/YYYY-MM-DD_HH-MM-SS/
+├── model/      # KAN model states
+├── plots/      # any DDR generated plots
+├── saved_models/
+    ├── ddr_{version}-{geodataset}-{mode}_epoch_1_mb_0.pt   # Checkpoint file
+    ...
+    └── ddr_{version}-{geodataset}-{mode}_epoch_5_mb_42.pt   # Checkpoint file
+├── pydantic_config.yaml     # Validated configuration
+└── ddr-{version}-{geodataset}-{mode}.log  # the log file of all information generated during training
+```
+
+## Next Steps
+
+- [Model Training](usage/train.md): Detailed training guide
+- [Model Testing](usage/test.md): Evaluate your trained model
+- [Routing](usage/routing.md): Run inference with trained weights
+- [Engine](engine/index.md): Learn about data preparation

--- a/src/ddr/nn/kan.py
+++ b/src/ddr/nn/kan.py
@@ -40,10 +40,12 @@ class kan(torch.nn.Module):
                     device=device,
                 )
             )
-        self.output = torch.nn.Linear(self.hidden_size, self.output_size, bias=False, device=device)
-        torch.nn.init.xavier_normal_(self.input.weight)
-        torch.nn.init.xavier_normal_(self.output.weight)
+        self.output = torch.nn.Linear(self.hidden_size, self.output_size, bias=True, device=device)
+
+        torch.nn.init.kaiming_normal_(self.input.weight, nonlinearity="relu")
+        torch.nn.init.xavier_normal_(self.output.weight, gain=0.1)
         torch.nn.init.zeros_(self.input.bias)
+        torch.nn.init.zeros_(self.output.bias)
 
     def forward(self, *args: Any, **kwargs: Any) -> dict[str, torch.Tensor]:
         """Forward pass of the neural network"""

--- a/src/ddr/routing/mmc.py
+++ b/src/ddr/routing/mmc.py
@@ -207,20 +207,30 @@ class MuskingumCunge:
 
         # Setup spatial parameters
         self.spatial_parameters = spatial_parameters
-        self.n = denormalize(value=spatial_parameters["n"], bounds=self.parameter_bounds["n"])
+        log_space_params = self.cfg.params.log_space_parameters
+        self.n = denormalize(
+            value=spatial_parameters["n"],
+            bounds=self.parameter_bounds["n"],
+            log_space="n" in log_space_params,
+        )
         self.q_spatial = denormalize(
             value=spatial_parameters["q_spatial"],
             bounds=self.parameter_bounds["q_spatial"],
+            log_space="q_spatial" in log_space_params,
         )
         if routing_dataclass.top_width.numel() == 0:
             self.top_width = denormalize(
-                value=spatial_parameters["top_width"], bounds=self.parameter_bounds["top_width"]
+                value=spatial_parameters["top_width"],
+                bounds=self.parameter_bounds["top_width"],
+                log_space="top_width" in log_space_params,
             )
         else:
             self.top_width = routing_dataclass.top_width.to(self.device).to(torch.float32)
         if routing_dataclass.side_slope.numel() == 0:
             self.side_slope = denormalize(
-                value=spatial_parameters["side_slope"], bounds=self.parameter_bounds["side_slope"]
+                value=spatial_parameters["side_slope"],
+                bounds=self.parameter_bounds["side_slope"],
+                log_space="side_slope" in log_space_params,
             )
         else:
             self.side_slope = routing_dataclass.side_slope.to(self.device).to(torch.float32)

--- a/src/ddr/validation/configs.py
+++ b/src/ddr/validation/configs.py
@@ -90,7 +90,7 @@ class Params(BaseModel):
     )
     parameter_ranges: dict[str, list[float]] = Field(
         default_factory=lambda: {
-            "n": [0.02, 0.2],  # (m⁻¹/³s)
+            "n": [0.015, 0.25],  # (m⁻¹/³s)
             "q_spatial": [0.0, 1.0],  # 0 = rectangular, 1 = triangular
             "top_width": [1.0, 5000.0],  # Log-space (m)
             "side_slope": [0.5, 50.0],  # H:V ratio Log-space (-)

--- a/src/ddr/validation/configs.py
+++ b/src/ddr/validation/configs.py
@@ -90,10 +90,19 @@ class Params(BaseModel):
     )
     parameter_ranges: dict[str, list[float]] = Field(
         default_factory=lambda: {
-            "n": [0.01, 0.35],
-            "q_spatial": [0.0, 3.0],
+            "n": [0.02, 0.2],  # (m⁻¹/³s)
+            "q_spatial": [0.0, 1.0],  # 0 = rectangular, 1 = triangular
+            "top_width": [1.0, 6000.0],  # Log-space (m)
+            "side_slope": [0.5, 50.0],  # H:V ratio Log-space (-)
         },
         description="The parameter space bounds [min, max] to project learned physical values to",
+    )
+    log_space_parameters: list[str] = Field(
+        default_factory=lambda: [
+            "top_width",
+            "side_slope",
+        ],
+        description="Parameters to denormalize in log-space for right-skewed distributions",
     )
     defaults: dict[str, int | float] = Field(
         default_factory=lambda: {

--- a/src/ddr/validation/configs.py
+++ b/src/ddr/validation/configs.py
@@ -92,7 +92,7 @@ class Params(BaseModel):
         default_factory=lambda: {
             "n": [0.02, 0.2],  # (m⁻¹/³s)
             "q_spatial": [0.0, 1.0],  # 0 = rectangular, 1 = triangular
-            "top_width": [1.0, 6000.0],  # Log-space (m)
+            "top_width": [1.0, 5000.0],  # Log-space (m)
             "side_slope": [0.5, 50.0],  # H:V ratio Log-space (-)
         },
         description="The parameter space bounds [min, max] to project learned physical values to",

--- a/zensical.toml
+++ b/zensical.toml
@@ -4,7 +4,7 @@ site_description = "A differentiable routing library for large-scale runoff calc
 site_author = "Tadd Bindas"
 site_url = "https://deepgroundwater.com/ddr"
 copyright = """
-Copyright &copy; 2025 DeepGroundwater
+Copyright &copy; 2026 DeepGroundwater
 """
 repo_url = "https://github.com/DeepGroundwater/ddr"
 repo_name = "deepgroundwater/ddr"


### PR DESCRIPTION
## Issue Addressed

The values learned from `top_width` and `side_slope` were not being correctly learned from their large parameter ranges. 
<img width="690" height="390" alt="image" src="https://github.com/user-attachments/assets/2a8a3538-49e6-496e-8326-0986412fdfcf" />
<img width="690" height="390" alt="image" src="https://github.com/user-attachments/assets/5ebbfaed-fd93-449f-a147-af2ea1ce475f" />

Given that these parameter ranges are right-tail distributed, it makes more sense for these parameters to be de-normalized in a log-norm fashion

Additionally, more docs were added to DDR

## Description

- added a new parameter in `denormalize` to assist with log-norm transformations
- changed parameter ranges to be more realistic
- changed initialization from MLP -> KAN to add bias terms + spread out the parameter ranges entering latent space

After the log-normalization parameter ranges look like the following:
<img width="690" height="390" alt="image" src="https://github.com/user-attachments/assets/19b63b99-fff8-412d-a173-60e54c28f32c" />
<img width="690" height="390" alt="image" src="https://github.com/user-attachments/assets/0ee8db73-2b98-4dbc-acaa-c3b63488904a" />

which is much more reasonable. `top_width` is in meters and `side_slope` is unitless Horizontal / Vertical (run / rise). This would mean a larger value means a flatter river.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [X] Documentation update

Other (please specify):

## Checklist

- [X] Branch is up to date with master
- [ ] Updated tests or added new tests
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [ ] Code follows established style and conventions
