### PR TITLE
Consolidate COO Binsparse I/O in Engine Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,6 @@ examples/eval/*.zarr
 
 # scratch notebooks
 examples/scratch
+
+# claude
+Claude.md

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -127,6 +127,12 @@ DDR uses sparse COO (Coordinate) matrices to represent river network connectivit
 # A[i, j] = 1 means flow goes from segment j to segment i
 ```
 
+The matrices are stored in zarr v3 format following the [Binsparse COO specification](engine/binsparse.md). See the binsparse documentation for details on:
+
+- Reading and writing adjacency matrices programmatically
+- Order converters for MERIT and Lynker ID formats
+- Per-gauge subset structure
+
 The engine scripts automatically create these matrices:
 
 ```bash

--- a/docs/engine/binsparse.md
+++ b/docs/engine/binsparse.md
@@ -1,0 +1,261 @@
+---
+icon: lucide/binary
+---
+
+# Binsparse COO Format
+
+DDR uses a zarr-based storage format for sparse COO (Coordinate) matrices, inspired by the [binsparse specification](https://github.com/ivirshup/binsparse-python). This format efficiently stores river network connectivity for routing computations.
+
+## Format Overview
+
+Each adjacency matrix is stored as a zarr v3 group containing arrays and metadata attributes.
+
+### Arrays
+
+| Array | Type | Description |
+|-------|------|-------------|
+| `indices_0` | int32 | Row indices (downstream segment indices) |
+| `indices_1` | int32 | Column indices (upstream segment indices) |
+| `values` | uint8 | Matrix values (1 for connected, 0 otherwise) |
+| `order` | int32 | Topological sort order as domain-specific IDs |
+
+### Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `format` | str | Always "COO" |
+| `shape` | [int, int] | Matrix dimensions [rows, cols] |
+| `data_types` | dict | Dtype strings for each array |
+| `gage_catchment` | int/str | Origin catchment ID (gauge subsets only) |
+| `gage_idx` | int | CONUS matrix index (gauge subsets only) |
+
+## Matrix Structure
+
+The adjacency matrix is **lower triangular**, where `A[i, j] = 1` indicates that flow goes from segment `j` (column) to segment `i` (row). This structure ensures topological ordering: upstream segments always have lower indices than downstream segments.
+
+```
+     0  1  2  3  4   (upstream)
+   ┌─────────────┐
+ 0 │ 0           │   Flow direction: column → row
+ 1 │ 1  0        │   Example: A[1,0]=1 means 0→1
+ 2 │ 0  1  0     │            A[2,1]=1 means 1→2
+ 3 │ 0  0  1  0  │            A[4,3]=1 means 3→4
+ 4 │ 0  0  1  1  0│            A[4,2]=1 means 2→4
+   └─────────────┘
+(downstream)
+```
+
+## Order Converters
+
+Different hydrofabric datasets use different ID formats. Order converters translate between domain-specific IDs and the integer format stored in zarr.
+
+### MERIT Hydro
+
+MERIT uses integer COMIDs. The conversion is straightforward:
+
+```python
+from ddr_engine import merit_converter
+
+# Domain IDs: [12345, 12346, 12347]
+# Zarr storage: np.array([12345, 12346, 12347], dtype=np.int32)
+
+zarr_order = merit_converter.to_zarr([12345, 12346, 12347])
+comids = merit_converter.from_zarr(zarr_order)
+```
+
+### Lynker Hydrofabric
+
+Lynker uses string IDs like "wb-123". The converter extracts the numeric portion:
+
+```python
+from ddr_engine import lynker_converter
+
+# Domain IDs: ["wb-123", "wb-456", "wb-789"]
+# Zarr storage: np.array([123, 456, 789], dtype=np.int32)
+
+zarr_order = lynker_converter.to_zarr(["wb-123", "wb-456", "wb-789"])
+wb_ids = lynker_converter.from_zarr(zarr_order)  # ["wb-123", "wb-456", "wb-789"]
+```
+
+## Reading Adjacency Matrices
+
+### Using Generic Functions
+
+```python
+from pathlib import Path
+from ddr_engine import coo_from_zarr_generic, merit_converter
+
+# Read MERIT adjacency matrix
+coo, ts_order = coo_from_zarr_generic(
+    Path("data/merit_conus_adjacency.zarr"),
+    merit_converter
+)
+
+# coo: scipy.sparse.coo_matrix
+# ts_order: list[int] of COMIDs in topological order
+```
+
+### Using Dataset-Specific Functions
+
+```python
+from pathlib import Path
+from ddr_engine.merit.io import coo_from_zarr
+
+# MERIT - returns COMIDs as integers
+coo, ts_order = coo_from_zarr(Path("data/merit_conus_adjacency.zarr"))
+
+from ddr_engine.lynker_hydrofabric.io import coo_from_zarr
+
+# Lynker - returns wb-* strings
+coo, ts_order = coo_from_zarr(Path("data/hydrofabric_v2.2_conus_adjacency.zarr"))
+```
+
+### Reading Gauge Subsets
+
+Gauge subsets are stored in a zarr group with one subgroup per gauge:
+
+```python
+import zarr
+
+# Open the gauge zarr store
+root = zarr.open_group("data/merit_gages_conus_adjacency.zarr", mode="r")
+
+# Each gauge is a subgroup keyed by station ID
+gauge_group = root["01570500"]
+
+# Access arrays
+row = gauge_group["indices_0"][:]
+col = gauge_group["indices_1"][:]
+data = gauge_group["values"][:]
+order = gauge_group["order"][:]
+
+# Access metadata
+shape = tuple(gauge_group.attrs["shape"])
+gage_catchment = gauge_group.attrs["gage_catchment"]
+gage_idx = gauge_group.attrs["gage_idx"]
+```
+
+## Writing Adjacency Matrices
+
+### CONUS Full Network
+
+```python
+from pathlib import Path
+from scipy import sparse
+from ddr_engine import coo_to_zarr_generic, merit_converter
+
+# Create a COO matrix (example)
+row = [1, 2, 3, 4, 4]
+col = [0, 1, 2, 2, 3]
+data = [1, 1, 1, 1, 1]
+coo = sparse.coo_matrix((data, (row, col)), shape=(5, 5), dtype="uint8")
+
+# Topological order as COMIDs
+ts_order = [12345, 12346, 12347, 12348, 12349]
+
+# Write to zarr
+coo_to_zarr_generic(
+    coo,
+    ts_order,
+    Path("output/merit_conus_adjacency.zarr"),
+    merit_converter
+)
+```
+
+### Gauge Subsets
+
+```python
+import zarr
+from ddr_engine import coo_to_zarr_group_generic, merit_converter
+
+# Create/open the gauge zarr store
+store = zarr.storage.LocalStore(root="output/merit_gages_adjacency.zarr")
+root = zarr.create_group(store=store)
+
+# Create a subgroup for each gauge
+gauge_group = root.create_group("01570500")
+
+# Write the subset COO matrix
+coo_to_zarr_group_generic(
+    coo=subset_coo,
+    ts_order=[12345, 12346],  # COMIDs in subset
+    origin=12346,  # Gauge catchment COMID
+    gauge_root=gauge_group,
+    mapping={12345: 0, 12346: 1},  # COMID → CONUS index
+    converter=merit_converter
+)
+```
+
+## File Structure
+
+### CONUS Network
+
+```
+merit_conus_adjacency.zarr/
+├── zarr.json              # Group metadata
+├── indices_0/             # Row indices
+│   ├── zarr.json
+│   └── c/0
+├── indices_1/             # Column indices
+│   ├── zarr.json
+│   └── c/0
+├── values/                # Matrix values
+│   ├── zarr.json
+│   └── c/0
+└── order/                 # Topological order
+    ├── zarr.json
+    └── c/0
+```
+
+### Per-Gauge Subsets
+
+```
+merit_gages_conus_adjacency.zarr/
+├── zarr.json              # Root group metadata
+├── 01570500/              # Gauge station ID
+│   ├── zarr.json          # Subgroup metadata with gage_catchment, gage_idx
+│   ├── indices_0/
+│   ├── indices_1/
+│   ├── values/
+│   └── order/
+├── 01563500/
+│   └── ...
+└── ...
+```
+
+## Creating Adjacency Matrices
+
+The engine provides scripts to build adjacency matrices from raw hydrofabric data:
+
+### MERIT Hydro
+
+```bash
+uv run python -m ddr_engine.merit /path/to/riv_pfaf_X_MERIT_Hydro.shp \
+    --path data/ \
+    --gages streamflow_datasets/gage_info/dhbv2_gages.csv
+```
+
+### Lynker Hydrofabric v2.2
+
+```bash
+uv run python -m ddr_engine.lynker_hydrofabric /path/to/conus_nextgen.gpkg \
+    --path data/ \
+    --gages streamflow_datasets/gage_info/dhbv2_gages.csv
+```
+
+Both commands create:
+- `*_conus_adjacency.zarr`: Full CONUS river network
+- `*_gages_conus_adjacency.zarr`: Per-gauge upstream subnetworks
+
+## API Reference
+
+### Core Functions
+
+::: ddr_engine.core.coo_to_zarr_generic
+::: ddr_engine.core.coo_from_zarr_generic
+::: ddr_engine.core.coo_to_zarr_group_generic
+
+### Order Converters
+
+::: ddr_engine.core.MeritOrderConverter
+::: ddr_engine.core.LynkerOrderConverter

--- a/docs/engine/index.md
+++ b/docs/engine/index.md
@@ -8,35 +8,41 @@ The `engine/` workspace package contains build scripts and tools meant to format
 - Network/adjacency matrices for implicit muskingum cunge routing
 - Network/adjacency matrices for mapping gauge locations within geospatial datasets
 
-## Why have an `engine/` folder?
-
-The `engine/` folder is meant to contain all necessary code for generating end-to-end routing without having the need for extra repositories. The user only needs to provide the dataset (and unit-catchment flow predictions), and the code will have all of the tools needed for routing.
+The goal for the `engine/` package is to give all of the necessary data functions for DDR to the user. The user only needs to provide the dataset (and unit-catchment flow predictions), and the code will have all of the tools needed for routing.
 
 ## Why use a COO matrix?
 
 As explained [here](http://rapid-hub.org/docs/RAPID_Parallel_Computing.pdf#page=5.00) routing can be efficiently solved using a sparse network (otherwise known as an adjacency) matrix and a backwards linear solution. Storing these matrixes then becomes a choice of what format to use for universal readability and efficient storage. Thus, a sparse COO was chosen as COO is fast to turn into other formats, and is readable given only coordinates are stored.
 
-It was necessary to build the tools to convert datasets to their matrix form as river networks don't often ship in sparse form. We used the [Binsparse](https://github.com/ivirshup/binsparse-python) specification for storing the matrices. See the [Binsparse COO Format](binsparse.md) documentation for details on the storage format and API.
+It was necessary to build the tools to convert datasets to their matrix form as river networks don't often ship in sparse form. We used the Binsparse specification for storing the matrices. See the [Binsparse COO Format](binsparse.md) documentation for details on the storage format and API.
 
 ## Package API
 
-The `ddr_engine` package exports core I/O functions at the package level for convenient access:
+The `ddr_engine` package exports I/O functions at the package level:
 
 ```python
 from ddr_engine import (
-    coo_to_zarr_generic,    # Write COO matrix to zarr
-    coo_from_zarr_generic,  # Read COO matrix from zarr
-    coo_to_zarr_group_generic,  # Write gauge subset
-    merit_converter,        # MERIT COMID converter
-    lynker_converter,       # Lynker wb-* string converter
+    # Primary API (recommended)
+    coo_to_zarr,      # Write COO matrix (pass geodataset name)
+    coo_from_zarr,    # Read COO matrix (auto-detects geodataset)
+    coo_to_zarr_group,  # Write gauge subset
+
+    # Converter registry
+    list_geodatasets,    # List available geodatasets
+    register_converter,  # Register custom geodataset
 )
 ```
 
-For dataset-specific functions, use the submodule imports:
+### Example Usage
 
 ```python
-from ddr_engine.merit.io import coo_to_zarr, coo_from_zarr
-from ddr_engine.lynker_hydrofabric.io import coo_to_zarr, coo_from_zarr
+from ddr_engine import coo_to_zarr, coo_from_zarr
+
+# Write - specify geodataset name
+coo_to_zarr(coo, ts_order, Path("output.zarr"), "merit")
+
+# Read - auto-detects from metadata
+coo, ts_order = coo_from_zarr(Path("output.zarr"))
 ```
 
 ## Setup

--- a/docs/engine/index.md
+++ b/docs/engine/index.md
@@ -16,7 +16,28 @@ The `engine/` folder is meant to contain all necessary code for generating end-t
 
 As explained [here](http://rapid-hub.org/docs/RAPID_Parallel_Computing.pdf#page=5.00) routing can be efficiently solved using a sparse network (otherwise known as an adjacency) matrix and a backwards linear solution. Storing these matrixes then becomes a choice of what format to use for universal readability and efficient storage. Thus, a sparse COO was chosen as COO is fast to turn into other formats, and is readable given only coordinates are stored.
 
-It was necessary to build the tools to convert datasets to their matrix form as river networks don't often ship in sparse form. We used the [Binsparse](https://github.com/ivirshup/binsparse-python) specification for storing the matrices.
+It was necessary to build the tools to convert datasets to their matrix form as river networks don't often ship in sparse form. We used the [Binsparse](https://github.com/ivirshup/binsparse-python) specification for storing the matrices. See the [Binsparse COO Format](binsparse.md) documentation for details on the storage format and API.
+
+## Package API
+
+The `ddr_engine` package exports core I/O functions at the package level for convenient access:
+
+```python
+from ddr_engine import (
+    coo_to_zarr_generic,    # Write COO matrix to zarr
+    coo_from_zarr_generic,  # Read COO matrix from zarr
+    coo_to_zarr_group_generic,  # Write gauge subset
+    merit_converter,        # MERIT COMID converter
+    lynker_converter,       # Lynker wb-* string converter
+)
+```
+
+For dataset-specific functions, use the submodule imports:
+
+```python
+from ddr_engine.merit.io import coo_to_zarr, coo_from_zarr
+from ddr_engine.lynker_hydrofabric.io import coo_to_zarr, coo_from_zarr
+```
 
 ## Setup
 

--- a/engine/src/ddr_engine/__init__.py
+++ b/engine/src/ddr_engine/__init__.py
@@ -1,5 +1,47 @@
-"""DDR Engine - Hydrofabric data preparation tools."""
+"""DDR Engine - Hydrofabric data preparation tools.
+
+This package provides tools for building sparse COO adjacency matrices from
+hydrofabric datasets (MERIT Hydro, Lynker Hydrofabric v2.2).
+
+Core I/O Functions
+------------------
+The following generic I/O functions work with any hydrofabric dataset:
+
+- ``coo_to_zarr_generic``: Write a COO matrix to zarr
+- ``coo_from_zarr_generic``: Read a COO matrix from zarr
+- ``coo_to_zarr_group_generic``: Write a gauge subset COO matrix
+
+Order Converters
+----------------
+Use the appropriate converter for your dataset:
+
+- ``merit_converter``: For MERIT Hydro (integer COMIDs)
+- ``lynker_converter``: For Lynker Hydrofabric (wb-* string IDs)
+
+Example
+-------
+>>> from ddr_engine import coo_to_zarr_generic, merit_converter
+>>> from scipy import sparse
+>>> coo = sparse.coo_matrix(...)
+>>> coo_to_zarr_generic(coo, ts_order, Path("output.zarr"), merit_converter)
+"""
 
 from ._version import __version__
+from .core import (
+    coo_from_zarr_generic,
+    coo_to_zarr_generic,
+    coo_to_zarr_group_generic,
+    lynker_converter,
+    merit_converter,
+)
 
-__all__ = ["__version__"]
+__all__ = [
+    "__version__",
+    # Core I/O functions
+    "coo_to_zarr_generic",
+    "coo_from_zarr_generic",
+    "coo_to_zarr_group_generic",
+    # Order converters
+    "merit_converter",
+    "lynker_converter",
+]

--- a/engine/src/ddr_engine/__init__.py
+++ b/engine/src/ddr_engine/__init__.py
@@ -1,47 +1,64 @@
-"""DDR Engine - Hydrofabric data preparation tools.
+"""DDR Engine - Geodataset preparation tools.
 
 This package provides tools for building sparse COO adjacency matrices from
-hydrofabric datasets (MERIT Hydro, Lynker Hydrofabric v2.2).
+geodatasets (MERIT Hydro, Lynker Hydrofabric v2.2).
 
-Core I/O Functions
+Primary API
+-----------
+The recommended functions for reading and writing COO matrices:
+
+- ``coo_to_zarr``: Write a COO matrix (pass geodataset name)
+- ``coo_from_zarr``: Read a COO matrix (auto-detects geodataset)
+- ``coo_to_zarr_group``: Write a gauge subset COO matrix
+
+Converter Registry
 ------------------
-The following generic I/O functions work with any hydrofabric dataset:
-
-- ``coo_to_zarr_generic``: Write a COO matrix to zarr
-- ``coo_from_zarr_generic``: Read a COO matrix from zarr
-- ``coo_to_zarr_group_generic``: Write a gauge subset COO matrix
-
-Order Converters
-----------------
-Use the appropriate converter for your dataset:
-
-- ``merit_converter``: For MERIT Hydro (integer COMIDs)
-- ``lynker_converter``: For Lynker Hydrofabric (wb-* string IDs)
+Custom geodatasets can be registered with ``register_converter()``.
+List available geodatasets with ``list_geodatasets()``.
 
 Example
 -------
->>> from ddr_engine import coo_to_zarr_generic, merit_converter
+>>> from ddr_engine import coo_to_zarr, coo_from_zarr
 >>> from scipy import sparse
 >>> coo = sparse.coo_matrix(...)
->>> coo_to_zarr_generic(coo, ts_order, Path("output.zarr"), merit_converter)
+>>> coo_to_zarr(coo, ts_order, Path("output.zarr"), "merit")
+>>> coo, ts_order = coo_from_zarr(Path("output.zarr"))  # Auto-detects
 """
 
 from ._version import __version__
 from .core import (
+    # Primary API
+    coo_from_zarr,
+    # Generic API (low-level)
     coo_from_zarr_generic,
+    coo_to_zarr,
     coo_to_zarr_generic,
+    coo_to_zarr_group,
     coo_to_zarr_group_generic,
+    # Converter registry
+    get_converter,
+    list_geodatasets,
+    # Converter instances (for advanced use)
     lynker_converter,
     merit_converter,
+    register_converter,
 )
 
 __all__ = [
     "__version__",
-    # Core I/O functions
+    # Primary API (recommended)
+    "coo_to_zarr",
+    "coo_from_zarr",
+    "coo_to_zarr_group",
+    # Generic API (low-level)
     "coo_to_zarr_generic",
     "coo_from_zarr_generic",
     "coo_to_zarr_group_generic",
-    # Order converters
+    # Converter registry
+    "get_converter",
+    "register_converter",
+    "list_geodatasets",
+    # Converter instances (for advanced use)
     "merit_converter",
     "lynker_converter",
 ]

--- a/engine/src/ddr_engine/core/__init__.py
+++ b/engine/src/ddr_engine/core/__init__.py
@@ -1,32 +1,59 @@
 """Core module for shared engine functionality.
 
-This module provides generic COO zarr I/O functions and converters for
-translating between domain-specific IDs (MERIT COMIDs, Lynker wb-* strings)
-and the integer format used in zarr storage.
+This module provides COO zarr I/O functions and converters for translating
+between domain-specific IDs (MERIT COMIDs, Lynker wb-* strings) and the
+integer format used in zarr storage.
+
+Primary API
+-----------
+The recommended functions auto-detect or accept geodataset names:
+
+- ``coo_to_zarr``: Write a COO matrix (takes geodataset name)
+- ``coo_from_zarr``: Read a COO matrix (auto-detects geodataset)
+- ``coo_to_zarr_group``: Write a gauge subset (takes geodataset name)
+
+Converter Registry
+------------------
+Register custom converters with ``register_converter()`` and list available
+geodatasets with ``list_geodatasets()``.
 """
 
 from .converters import (
     LynkerOrderConverter,
     MeritOrderConverter,
     OrderConverter,
+    get_converter,
+    list_geodatasets,
     lynker_converter,
     merit_converter,
+    register_converter,
 )
 from .zarr_io import (
+    coo_from_zarr,
     coo_from_zarr_generic,
+    coo_to_zarr,
     coo_to_zarr_generic,
+    coo_to_zarr_group,
     coo_to_zarr_group_generic,
 )
 
 __all__ = [
-    # Converters
+    # Primary API (recommended)
+    "coo_to_zarr",
+    "coo_from_zarr",
+    "coo_to_zarr_group",
+    # Generic API (low-level)
+    "coo_to_zarr_generic",
+    "coo_from_zarr_generic",
+    "coo_to_zarr_group_generic",
+    # Converter registry
+    "get_converter",
+    "register_converter",
+    "list_geodatasets",
+    # Converter classes and instances
     "OrderConverter",
     "MeritOrderConverter",
     "LynkerOrderConverter",
     "merit_converter",
     "lynker_converter",
-    # Zarr I/O
-    "coo_to_zarr_generic",
-    "coo_from_zarr_generic",
-    "coo_to_zarr_group_generic",
 ]

--- a/engine/src/ddr_engine/core/__init__.py
+++ b/engine/src/ddr_engine/core/__init__.py
@@ -1,0 +1,32 @@
+"""Core module for shared engine functionality.
+
+This module provides generic COO zarr I/O functions and converters for
+translating between domain-specific IDs (MERIT COMIDs, Lynker wb-* strings)
+and the integer format used in zarr storage.
+"""
+
+from .converters import (
+    LynkerOrderConverter,
+    MeritOrderConverter,
+    OrderConverter,
+    lynker_converter,
+    merit_converter,
+)
+from .zarr_io import (
+    coo_from_zarr_generic,
+    coo_to_zarr_generic,
+    coo_to_zarr_group_generic,
+)
+
+__all__ = [
+    # Converters
+    "OrderConverter",
+    "MeritOrderConverter",
+    "LynkerOrderConverter",
+    "merit_converter",
+    "lynker_converter",
+    # Zarr I/O
+    "coo_to_zarr_generic",
+    "coo_from_zarr_generic",
+    "coo_to_zarr_group_generic",
+]

--- a/engine/src/ddr_engine/core/converters.py
+++ b/engine/src/ddr_engine/core/converters.py
@@ -1,0 +1,110 @@
+"""Converters for translating between domain-specific IDs and zarr storage format.
+
+Each engine (MERIT, Lynker) has its own ID format. These converters handle the
+translation between domain IDs and the integer format used in zarr storage.
+"""
+
+from typing import Any, Protocol
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+class OrderConverter(Protocol):
+    """Protocol for order converters."""
+
+    def to_zarr(self, ids: list) -> NDArray[np.int32]:
+        """Convert domain IDs to zarr order array."""
+        ...
+
+    def from_zarr(self, order: NDArray[np.int32]) -> list:
+        """Convert zarr order array back to domain IDs."""
+        ...
+
+
+class MeritOrderConverter:
+    """Converter for MERIT COMIDs (integers)."""
+
+    def to_zarr(self, comids: list[int]) -> NDArray[np.int32]:
+        """Convert COMID list to zarr order array.
+
+        MERIT COMIDs are already integers, so this is an identity conversion.
+
+        Parameters
+        ----------
+        comids : list[int]
+            List of COMID integers.
+
+        Returns
+        -------
+        NDArray[np.int32]
+            Array of COMIDs as int32.
+        """
+        return np.array(comids, dtype=np.int32)
+
+    def from_zarr(self, order: NDArray[np.int32]) -> Any:
+        """Convert zarr order array back to COMID list.
+
+        Parameters
+        ----------
+        order : NDArray[np.int32]
+            Array of COMIDs from zarr.
+
+        Returns
+        -------
+        Any
+            List of COMID integers.
+        """
+        return order.tolist()
+
+
+class LynkerOrderConverter:
+    """Converter for Lynker Hydrofabric IDs (wb-* strings)."""
+
+    def to_zarr(self, wb_ids: list[str]) -> NDArray[np.int32]:
+        """Convert watershed boundary ID list to zarr order array.
+
+        Extracts the numeric portion from "wb-123" or "ghost-0" format strings.
+
+        Parameters
+        ----------
+        wb_ids : list[str]
+            List of watershed boundary IDs (e.g., ["wb-123", "wb-456"]).
+
+        Returns
+        -------
+        NDArray[np.int32]
+            Array of extracted numeric IDs as int32.
+        """
+        return np.array(
+            [int(float(_id.split("-")[1])) for _id in wb_ids],
+            dtype=np.int32,
+        )
+
+    def from_zarr(self, order: NDArray[np.int32]) -> list[str]:
+        """Convert zarr order array back to watershed boundary ID list.
+
+        Reconstructs "wb-{n}" format strings from numeric values.
+
+        Parameters
+        ----------
+        order : NDArray[np.int32]
+            Array of numeric IDs from zarr.
+
+        Returns
+        -------
+        list[str]
+            List of watershed boundary IDs (e.g., ["wb-123", "wb-456"]).
+
+        Notes
+        -----
+        Ghost nodes (negative IDs or IDs that were originally "ghost-*") cannot
+        be distinguished from regular wb-* IDs after zarr storage. This function
+        always reconstructs as "wb-{n}".
+        """
+        return [f"wb-{n}" for n in order.tolist()]
+
+
+# Convenience instances
+merit_converter = MeritOrderConverter()
+lynker_converter = LynkerOrderConverter()

--- a/engine/src/ddr_engine/core/zarr_io.py
+++ b/engine/src/ddr_engine/core/zarr_io.py
@@ -1,0 +1,212 @@
+"""Generic zarr I/O utilities for COO adjacency matrices.
+
+This module provides engine-agnostic functions for reading and writing
+sparse COO matrices to zarr format. Engine-specific behavior is handled
+via order converters.
+
+Binsparse COO Format (zarr v3)
+==============================
+
+This module implements a zarr-based storage format for sparse COO matrices,
+inspired by the binsparse specification (https://github.com/ivirshup/binsparse-python).
+
+Arrays
+------
+Each zarr group contains the following arrays:
+
+- ``indices_0`` : int32
+    Row indices of non-zero elements (downstream segment indices).
+- ``indices_1`` : int32
+    Column indices of non-zero elements (upstream segment indices).
+- ``values`` : uint8
+    Matrix values (typically 1 for adjacency).
+- ``order`` : int32
+    Topological sort order as domain-specific IDs. For MERIT, these are
+    COMIDs (integers). For Lynker, these are numeric portions of wb-* strings.
+
+Attributes
+----------
+The zarr group stores the following attributes:
+
+- ``format`` : str
+    Always "COO" to indicate coordinate format.
+- ``shape`` : list[int, int]
+    Matrix dimensions [rows, cols].
+- ``data_types`` : dict
+    Dtype strings for indices_0, indices_1, and values.
+- ``gage_catchment`` : int | str (gauge subsets only)
+    Origin catchment ID for the gauge.
+- ``gage_idx`` : int (gauge subsets only)
+    Index of the gauge catchment in the CONUS adjacency matrix.
+
+Matrix Structure
+----------------
+The adjacency matrix is lower triangular, where A[i, j] = 1 indicates that
+flow goes from segment j (column) to segment i (row). This structure ensures
+topological ordering: upstream segments always have lower indices than
+downstream segments.
+
+Order Converters
+----------------
+Different hydrofabric datasets use different ID formats:
+
+- **MERIT**: Integer COMIDs (stored directly as int32)
+- **Lynker Hydrofabric**: String IDs like "wb-123" (numeric portion extracted)
+
+Use the appropriate converter when reading/writing:
+
+- ``merit_converter``: For MERIT Hydro datasets
+- ``lynker_converter``: For Lynker Hydrofabric v2.2
+
+Example
+-------
+Writing a COO matrix:
+
+    >>> from ddr_engine import coo_to_zarr_generic, merit_converter
+    >>> from scipy import sparse
+    >>> coo = sparse.coo_matrix(...)
+    >>> ts_order = [12345, 12346, 12347]  # MERIT COMIDs
+    >>> coo_to_zarr_generic(coo, ts_order, Path("output.zarr"), merit_converter)
+
+Reading a COO matrix:
+
+    >>> from ddr_engine import coo_from_zarr_generic, merit_converter
+    >>> coo, ts_order = coo_from_zarr_generic(Path("output.zarr"), merit_converter)
+    >>> print(ts_order)  # [12345, 12346, 12347]
+"""
+
+from pathlib import Path
+from typing import Any
+
+import zarr
+from scipy import sparse
+
+from .converters import OrderConverter
+
+
+def coo_to_zarr_generic(
+    coo: sparse.coo_matrix,
+    ts_order: list,
+    out_path: Path,
+    converter: OrderConverter,
+) -> None:
+    """
+    Save a COO adjacency matrix to a zarr group.
+
+    Parameters
+    ----------
+    coo : sparse.coo_matrix
+        Lower triangular adjacency matrix.
+    ts_order : list
+        Topological sort order of flowpaths (domain-specific IDs).
+    out_path : Path
+        Path to save the zarr group.
+    converter : OrderConverter
+        Converter to translate domain IDs to zarr storage format.
+    """
+    store = zarr.storage.LocalStore(root=out_path)
+    root = zarr.create_group(store=store)
+
+    zarr_order = converter.to_zarr(ts_order)
+
+    indices_0 = root.create_array(name="indices_0", shape=coo.row.shape, dtype=coo.row.dtype)
+    indices_1 = root.create_array(name="indices_1", shape=coo.col.shape, dtype=coo.row.dtype)
+    values = root.create_array(name="values", shape=coo.data.shape, dtype=coo.data.dtype)
+    order = root.create_array(name="order", shape=zarr_order.shape, dtype=zarr_order.dtype)
+
+    indices_0[:] = coo.row
+    indices_1[:] = coo.col
+    values[:] = coo.data
+    order[:] = zarr_order
+
+    root.attrs["format"] = "COO"
+    root.attrs["shape"] = list(coo.shape)
+    root.attrs["data_types"] = {
+        "indices_0": str(coo.row.dtype),
+        "indices_1": str(coo.col.dtype),
+        "values": str(coo.data.dtype),
+    }
+
+    print(f"Adjacency matrix written to zarr at {out_path}")
+
+
+def coo_from_zarr_generic(
+    zarr_path: Path,
+    converter: OrderConverter,
+) -> tuple[sparse.coo_matrix, list]:
+    """
+    Load a COO adjacency matrix from a zarr group.
+
+    Parameters
+    ----------
+    zarr_path : Path
+        Path to the zarr group.
+    converter : OrderConverter
+        Converter to translate zarr storage format back to domain IDs.
+
+    Returns
+    -------
+    tuple[sparse.coo_matrix, list]
+        The COO matrix and topological order (in domain-specific ID format).
+    """
+    root = zarr.open_group(store=zarr_path, mode="r")
+
+    row = root["indices_0"][:]
+    col = root["indices_1"][:]
+    data = root["values"][:]
+    shape = tuple(root.attrs["shape"])
+    order_array = root["order"][:]
+
+    coo = sparse.coo_matrix((data, (row, col)), shape=shape)
+    ts_order = converter.from_zarr(order_array)
+
+    return coo, ts_order
+
+
+def coo_to_zarr_group_generic(
+    coo: sparse.coo_matrix,
+    ts_order: list,
+    origin: Any,
+    gauge_root: zarr.Group,
+    mapping: dict,
+    converter: OrderConverter,
+) -> None:
+    """
+    Save a COO matrix to a zarr group for a gauge subset.
+
+    Parameters
+    ----------
+    coo : sparse.coo_matrix
+        Lower triangular adjacency matrix.
+    ts_order : list
+        Domain-specific IDs in topological sort order.
+    origin : Any
+        The origin ID of the gauge (domain-specific type).
+    gauge_root : zarr.Group
+        The zarr group for the subset COO matrix.
+    mapping : dict
+        Mapping of domain ID to its position in the CONUS array.
+    converter : OrderConverter
+        Converter to translate domain IDs to zarr storage format.
+    """
+    zarr_order = converter.to_zarr(ts_order)
+
+    indices_0 = gauge_root.create_array(name="indices_0", shape=coo.row.shape, dtype=coo.row.dtype)
+    indices_1 = gauge_root.create_array(name="indices_1", shape=coo.col.shape, dtype=coo.row.dtype)
+    values = gauge_root.create_array(name="values", shape=coo.data.shape, dtype=coo.data.dtype)
+    order_array = gauge_root.create_array(name="order", shape=zarr_order.shape, dtype=zarr_order.dtype)
+
+    indices_0[:] = coo.row
+    indices_1[:] = coo.col
+    values[:] = coo.data
+    order_array[:] = zarr_order
+
+    gauge_root.attrs["format"] = "COO"
+    gauge_root.attrs["shape"] = list(coo.shape)
+    gauge_root.attrs["gage_catchment"] = origin if isinstance(origin, int | str) else str(origin)
+    gauge_root.attrs["gage_idx"] = int(mapping[origin])
+    gauge_root.attrs["data_types"] = {
+        "indices_0": str(coo.row.dtype),
+        "indices_1": str(coo.col.dtype),
+        "values": str(coo.data.dtype),
+    }

--- a/engine/src/ddr_engine/lynker_hydrofabric/io.py
+++ b/engine/src/ddr_engine/lynker_hydrofabric/io.py
@@ -1,7 +1,13 @@
 """IO utilities for reading and writing Lynker Hydrofabric adjacency matrices to zarr.
 
-This module provides Lynker-specific wrappers around the generic COO zarr I/O
-functions in ddr_engine.core.zarr_io. Lynker uses wb-* string IDs as identifiers.
+This module provides Lynker-specific wrappers around the core COO zarr I/O
+functions. Lynker uses wb-* string IDs as identifiers.
+
+For most use cases, prefer the auto-detecting functions from ddr_engine:
+
+    >>> from ddr_engine import coo_to_zarr, coo_from_zarr
+    >>> coo_to_zarr(coo, ts_order, path, "lynker")
+    >>> coo, ts_order = coo_from_zarr(path)  # Auto-detects
 """
 
 from pathlib import Path
@@ -20,6 +26,8 @@ from ddr_engine.core import (
     coo_to_zarr_group_generic,
     lynker_converter,
 )
+
+GEODATASET = "lynker"
 
 
 def index_matrix(matrix: np.ndarray, fp: pd.DataFrame) -> pd.DataFrame:
@@ -159,7 +167,7 @@ def coo_to_zarr(coo: sparse.coo_matrix, ts_order: list[str], out_path: Path) -> 
     out_path : Path
         Path to save the zarr group.
     """
-    coo_to_zarr_generic(coo, ts_order, out_path, lynker_converter)
+    coo_to_zarr_generic(coo, ts_order, out_path, lynker_converter, geodataset=GEODATASET)
 
 
 def coo_to_zarr_group(
@@ -185,7 +193,9 @@ def coo_to_zarr_group(
     conus_mapping : dict[str, int]
         Mapping of watershed boundary ID to its position in the CONUS array.
     """
-    coo_to_zarr_group_generic(coo, ts_order, origin, gauge_root, conus_mapping, lynker_converter)
+    coo_to_zarr_group_generic(
+        coo, ts_order, origin, gauge_root, conus_mapping, lynker_converter, geodataset=GEODATASET
+    )
 
 
 def coo_from_zarr(zarr_path: Path) -> tuple[sparse.coo_matrix, list[str]]:

--- a/engine/src/ddr_engine/merit/io.py
+++ b/engine/src/ddr_engine/merit/io.py
@@ -1,4 +1,8 @@
-"""IO utilities for reading and writing adjacency matrices to zarr"""
+"""IO utilities for reading and writing MERIT adjacency matrices to zarr.
+
+This module provides MERIT-specific wrappers around the generic COO zarr I/O
+functions in ddr_engine.core.zarr_io. MERIT uses integer COMIDs as identifiers.
+"""
 
 from pathlib import Path
 
@@ -6,6 +10,13 @@ import numpy as np
 import rustworkx as rx
 import zarr
 from scipy import sparse
+
+from ddr_engine.core import (
+    coo_from_zarr_generic,
+    coo_to_zarr_generic,
+    coo_to_zarr_group_generic,
+    merit_converter,
+)
 
 
 def coo_to_zarr(
@@ -25,30 +36,7 @@ def coo_to_zarr(
     out_path : Path
         Path to save the zarr group.
     """
-    store = zarr.storage.LocalStore(root=out_path)
-    root = zarr.create_group(store=store)
-
-    _order = np.array(ts_order, dtype=np.int32)
-
-    indices_0 = root.create_array(name="indices_0", shape=coo.row.shape, dtype=coo.row.dtype)
-    indices_1 = root.create_array(name="indices_1", shape=coo.col.shape, dtype=coo.row.dtype)
-    values = root.create_array(name="values", shape=coo.data.shape, dtype=coo.data.dtype)
-    order = root.create_array(name="order", shape=_order.shape, dtype=_order.dtype)
-
-    indices_0[:] = coo.row
-    indices_1[:] = coo.col
-    values[:] = coo.data
-    order[:] = _order
-
-    root.attrs["format"] = "COO"
-    root.attrs["shape"] = list(coo.shape)
-    root.attrs["data_types"] = {
-        "indices_0": str(coo.row.dtype),
-        "indices_1": str(coo.col.dtype),
-        "values": str(coo.data.dtype),
-    }
-
-    print(f"Adjacency matrix written to zarr at {out_path}")
+    coo_to_zarr_generic(coo, ts_order, out_path, merit_converter)
 
 
 def coo_to_zarr_group(
@@ -74,27 +62,7 @@ def coo_to_zarr_group(
     merit_mapping : dict[int, int]
         Mapping of COMID to its position in the array
     """
-    zarr_order = np.array(ts_order, dtype=np.int32)
-
-    indices_0 = gauge_root.create_array(name="indices_0", shape=coo.row.shape, dtype=coo.row.dtype)
-    indices_1 = gauge_root.create_array(name="indices_1", shape=coo.col.shape, dtype=coo.row.dtype)
-    values = gauge_root.create_array(name="values", shape=coo.data.shape, dtype=coo.data.dtype)
-    order_array = gauge_root.create_array(name="order", shape=zarr_order.shape, dtype=zarr_order.dtype)
-
-    indices_0[:] = coo.row
-    indices_1[:] = coo.col
-    values[:] = coo.data
-    order_array[:] = zarr_order
-
-    gauge_root.attrs["format"] = "COO"
-    gauge_root.attrs["shape"] = list(coo.shape)
-    gauge_root.attrs["gage_catchment"] = int(origin_comid)
-    gauge_root.attrs["gage_idx"] = int(merit_mapping[origin_comid])
-    gauge_root.attrs["data_types"] = {
-        "indices_0": str(coo.row.dtype),
-        "indices_1": str(coo.col.dtype),
-        "values": str(coo.data.dtype),
-    }
+    coo_to_zarr_group_generic(coo, ts_order, origin_comid, gauge_root, merit_mapping, merit_converter)
 
 
 def coo_from_zarr(zarr_path: Path) -> tuple[sparse.coo_matrix, list[int]]:
@@ -109,19 +77,9 @@ def coo_from_zarr(zarr_path: Path) -> tuple[sparse.coo_matrix, list[int]]:
     Returns
     -------
     tuple[sparse.coo_matrix, list[int]]
-        The COO matrix and topological order.
+        The COO matrix and topological order (as COMID integers).
     """
-    root = zarr.open_group(store=zarr_path, mode="r")
-
-    row = root["indices_0"][:]
-    col = root["indices_1"][:]
-    data = root["values"][:]
-    shape = tuple(root.attrs["shape"])
-    ts_order = root["order"][:].tolist()
-
-    coo = sparse.coo_matrix((data, (row, col)), shape=shape)
-
-    return coo, ts_order
+    return coo_from_zarr_generic(zarr_path, merit_converter)
 
 
 def create_subset_coo(

--- a/engine/src/ddr_engine/merit/io.py
+++ b/engine/src/ddr_engine/merit/io.py
@@ -1,7 +1,13 @@
 """IO utilities for reading and writing MERIT adjacency matrices to zarr.
 
-This module provides MERIT-specific wrappers around the generic COO zarr I/O
-functions in ddr_engine.core.zarr_io. MERIT uses integer COMIDs as identifiers.
+This module provides MERIT-specific wrappers around the core COO zarr I/O
+functions. MERIT uses integer COMIDs as identifiers.
+
+For most use cases, prefer the auto-detecting functions from ddr_engine:
+
+    >>> from ddr_engine import coo_to_zarr, coo_from_zarr
+    >>> coo_to_zarr(coo, ts_order, path, "merit")
+    >>> coo, ts_order = coo_from_zarr(path)  # Auto-detects
 """
 
 from pathlib import Path
@@ -17,6 +23,8 @@ from ddr_engine.core import (
     coo_to_zarr_group_generic,
     merit_converter,
 )
+
+GEODATASET = "merit"
 
 
 def coo_to_zarr(
@@ -36,7 +44,7 @@ def coo_to_zarr(
     out_path : Path
         Path to save the zarr group.
     """
-    coo_to_zarr_generic(coo, ts_order, out_path, merit_converter)
+    coo_to_zarr_generic(coo, ts_order, out_path, merit_converter, geodataset=GEODATASET)
 
 
 def coo_to_zarr_group(
@@ -62,7 +70,9 @@ def coo_to_zarr_group(
     merit_mapping : dict[int, int]
         Mapping of COMID to its position in the array
     """
-    coo_to_zarr_group_generic(coo, ts_order, origin_comid, gauge_root, merit_mapping, merit_converter)
+    coo_to_zarr_group_generic(
+        coo, ts_order, origin_comid, gauge_root, merit_mapping, merit_converter, geodataset=GEODATASET
+    )
 
 
 def coo_from_zarr(zarr_path: Path) -> tuple[sparse.coo_matrix, list[int]]:

--- a/zensical.toml
+++ b/zensical.toml
@@ -18,6 +18,7 @@ nav = [
   ]},
   {"Engine" = [
      "engine/index.md",
+     "engine/binsparse.md"
   ]},
   {"Usage" = [
      "usage/index.md",


### PR DESCRIPTION
## Summary

- Consolidates all COO binsparse zarr I/O into `ddr_engine.core` as the canonical implementation
- Refactors MERIT and Lynker I/O modules to use shared generic functions
- Adds package-level exports for convenient access to core I/O functions
- Creates comprehensive binsparse format documentation

## Changes

### Engine Core Module (`ddr_engine.core`)
- `zarr_io.py`: Generic functions with binsparse format documentation
- `converters.py`: Order converters for MERIT (int COMIDs) and Lynker (wb-* strings)

### Refactored I/O Modules
- `merit/io.py`: Now uses `coo_to_zarr_generic`, `coo_from_zarr_generic`, `coo_to_zarr_group_generic`
- `lynker_hydrofabric/io.py`: Same refactoring + added missing `coo_from_zarr()`

### Package Exports (`ddr_engine.__init__.py`)
```python
from ddr_engine import (
    coo_to_zarr_generic,
    coo_from_zarr_generic,
    coo_to_zarr_group_generic,
    merit_converter,
    lynker_converter,
)
```

### Documentation
- New `docs/engine/binsparse.md` with format specification, examples, and API reference
- Updated `docs/engine/index.md` with package API section
- Updated `docs/datasets.md` to link to binsparse docs

## Test plan

- [x] All 224 tests pass (`uv run pytest tests/ -v`)
- [x] Package imports verified
- [x] Backward compatibility maintained (function signatures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)