### PR TITLE
feat: added hotstart and headwater benchmarks

### DIFF
--- a/docs/usage/hot_start.md
+++ b/docs/usage/hot_start.md
@@ -1,0 +1,98 @@
+---
+icon: lucide/flame
+---
+
+# Hot-Start Initialization
+
+When DDR begins routing, it needs an initial discharge value at every node in the river network. This page explains the hot start mechanism that computes a physically reasonable initial state.
+
+## The Problem
+
+Each routing batch requires an initial discharge $Q_0(i)$ at every segment $i$ before the first timestep can be routed. A naive approach sets $Q_0(i) = Q'_0(i)$ — the local lateral inflow at time $t{=}0$. This is a poor estimate because downstream segments should carry the accumulated flow from all upstream tributaries, not just their own local contribution.
+
+Consider a simple linear network with 5 reaches, each contributing 2 m$^3$/s of lateral inflow:
+
+| Node | Naive $Q_0$ | Correct $Q_0$ |
+|------|-------------|---------------|
+| 0 (headwater) | 2 | 2 |
+| 1 | 2 | 4 |
+| 2 | 2 | 6 |
+| 3 | 2 | 8 |
+| 4 (outlet) | 2 | 10 |
+
+The naive approach underestimates discharge at every non-headwater node, creating an artificial "ramp-up" period at the start of each training window.
+
+## The Solution: Topological Accumulation
+
+The hot-start computes accumulated discharge by solving:
+
+$$
+(\mathbf{I} - \mathbf{N}) \cdot \mathbf{Q}_0 = \mathbf{Q}'_0
+$$
+
+Where:
+
+- $\mathbf{N}$ is the adjacency matrix (lower triangular, $N_{ij} = 1$ if flow goes from $j$ to $i$)
+- $\mathbf{Q}'_0$ is the lateral inflow at $t{=}0$
+- $\mathbf{Q}_0$ is the initial discharge we want
+
+Expanding for a single node $i$:
+
+$$
+Q_0(i) - \sum_{j \in \text{upstream}(i)} Q_0(j) = Q'_0(i)
+$$
+
+$$
+Q_0(i) = Q'_0(i) + \sum_{j \in \text{upstream}(i)} Q_0(j)
+$$
+
+Because nodes are indexed in topological order (headwaters first, outlets last) and $\mathbf{I} - \mathbf{N}$ is lower triangular, this system is solved efficiently via forward substitution using `triangular_sparse_solve` — the same sparse solver used for each routing timestep.
+
+## When It Applies
+
+| Scenario | Initialization |
+|----------|---------------|
+| **Training** (every batch) | Hot-start via topological accumulation |
+| **Inference** (first batch) | Hot-start via topological accumulation |
+| **Inference** (subsequent batches) | State carried from previous batch (`carry_state=True`) |
+
+### Training
+
+Each training batch samples a random time window. There is no state to carry between batches, so every batch uses the hot-start. Combined with the warmup period (`cfg.experiment.warmup`), this gives the model a realistic starting point to route from.
+
+### Inference
+
+The first batch uses the hot-start. All subsequent batches pass `carry_state=True`, which preserves the discharge state from the end of the previous batch — maintaining physical continuity across the full simulation period.
+
+## Implementation
+
+The hot-start is implemented in `compute_hotstart_discharge()` in `src/ddr/routing/mmc.py`:
+
+```python
+from ddr.routing.mmc import compute_hotstart_discharge
+
+discharge_t0 = compute_hotstart_discharge(
+    q_prime_t0=q_prime[0],   # lateral inflow at t=0
+    mapper=mapper,           # PatternMapper from the network
+    discharge_lb=discharge_lb,
+    device=device,
+)
+```
+
+The function:
+
+1. Constructs the $(\mathbf{I} - \mathbf{N})$ matrix using the same `PatternMapper` and `fill_op` infrastructure as `route_timestep`
+2. Solves the lower-triangular system via `triangular_sparse_solve`
+3. Clamps the result to `discharge_lb` (physical lower bound)
+
+### Cost
+
+One sparse triangular solve per batch — identical cost to a single routing timestep. This is negligible compared to routing hundreds or thousands of timesteps per batch.
+
+### Differentiability
+
+`triangular_sparse_solve` has a custom backward pass, so gradients flow through the hot-start initialization during training.
+
+## Relationship to Summed Q'
+
+The hot-start solves the same mathematical problem as [Summed Lateral Flow](summed_q_prime.md), but at runtime rather than as a preprocessing step. The sparse solve approach avoids needing to precompute and store accumulated flows in the dataset, and naturally handles arbitrary subnetworks extracted for gauge-based training.

--- a/docs/usage/hot_start.md
+++ b/docs/usage/hot_start.md
@@ -85,9 +85,6 @@ The function:
 2. Solves the lower-triangular system via `triangular_sparse_solve`
 3. Clamps the result to `discharge_lb` (physical lower bound)
 
-### Cost
-
-One sparse triangular solve per batch — identical cost to a single routing timestep. This is negligible compared to routing hundreds or thousands of timesteps per batch.
 
 ### Differentiability
 

--- a/engine/scripts/build_hydrofabric_v2.2_matrices.py
+++ b/engine/scripts/build_hydrofabric_v2.2_matrices.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
         else:
             root = zarr.create_group(store=store)
 
-        for gauge in tqdm(gauge_set.gauges, desc="Creating Gauge COO matrices"):
+        for gauge in tqdm(gauge_set.gauges, desc="Creating Gauge COO matrices", ncols=140, ascii=True):
             try:
                 gauge_root = root.create_group(gauge.STAID)
             except zarr.errors.ContainsGroupError:

--- a/engine/src/ddr_engine/lynker_hydrofabric/build.py
+++ b/engine/src/ddr_engine/lynker_hydrofabric/build.py
@@ -107,7 +107,7 @@ def build_lynker_hydrofabric_gages_adjacency(
     else:
         root = zarr.create_group(store=store)
 
-    for gauge in tqdm(gauge_set.gauges, desc="Creating Gauge COO matrices"):
+    for gauge in tqdm(gauge_set.gauges, desc="Creating Gauge COO matrices", ncols=140, ascii=True):
         try:
             gauge_root = root.create_group(gauge.STAID)
         except zarr.errors.ContainsGroupError:

--- a/engine/src/ddr_engine/lynker_hydrofabric/build.py
+++ b/engine/src/ddr_engine/lynker_hydrofabric/build.py
@@ -121,7 +121,7 @@ def build_lynker_hydrofabric_gages_adjacency(
             continue
         connections = subset(origin, wb_network_dict)
         if len(connections) == 0:
-            print(f"Gauge: {gauge.STAID} is a headwater catchment (single reach)")
+            # print(f"Gauge: {gauge.STAID} is a headwater catchment (single reach)")
             coo = sparse.coo_matrix((len(ts_order_dict), len(ts_order_dict)), dtype=np.int8)
             subset_flowpaths = [origin]
         else:

--- a/engine/src/ddr_engine/lynker_hydrofabric/io.py
+++ b/engine/src/ddr_engine/lynker_hydrofabric/io.py
@@ -94,7 +94,7 @@ def create_matrix(
     # in this graph form -- each waterbody/flowpath is a node and each nexus is a directed edge
     # All flowpaths are nodes, add them upfront...
     gidx = graph.add_nodes_from(fp.keys())
-    for idx in tqdm(gidx, desc="Building network graph"):
+    for idx in tqdm(gidx, desc="Building network graph", ncols=140, ascii=True):
         id = graph.get_node_data(idx)
         nex = fp[id][1]  # the downstream nexus id
         terminal = False
@@ -124,7 +124,7 @@ def create_matrix(
     col = []
     row = []
 
-    for node in tqdm(ts_order, "Creating sparse matrix indicies"):
+    for node in tqdm(ts_order, "Creating sparse matrix indicies", ncols=140, ascii=True):
         if graph.out_degree(node) == 0:  # terminal node
             continue
         id = graph.get_node_data(node)

--- a/engine/src/ddr_engine/merit/build.py
+++ b/engine/src/ddr_engine/merit/build.py
@@ -213,10 +213,10 @@ def build_gauge_adjacencies(
 
         subset_comids = subset_upstream(origin_comid, graph, node_indices)
 
-        if len(subset_comids) == 1:
-            print(
-                f"Gauge {str(staid).zfill(8)} (COMID {origin_comid}) is a headwater catchment (single reach)"
-            )
+        # if len(subset_comids) == 1:
+        #     print(
+        #         f"Gauge {str(staid).zfill(8)} (COMID {origin_comid}) is a headwater catchment (single reach)"
+        #     )
 
         coo, subset_list = create_subset_coo(subset_comids, merit_mapping, graph, node_indices)
 

--- a/engine/src/ddr_engine/merit/build.py
+++ b/engine/src/ddr_engine/merit/build.py
@@ -72,6 +72,15 @@ def create_adjacency_matrix(
         return create_adjacency_matrix(fp_filtered)
 
     id_order = [graph.get_node_data(gidx) for gidx in ts_order]
+
+    # Include isolated COMIDs (single-reach basins with no connections in the data)
+    all_comids = {int(c) for c in fp["COMID"].values}
+    connected_comids = set(id_order)
+    isolated_comids = sorted(all_comids - connected_comids)
+    if isolated_comids:
+        print(f"Adding {len(isolated_comids)} isolated COMIDs (no upstream/downstream connections)")
+    id_order = id_order + isolated_comids
+
     idx_map = {id: idx for idx, id in enumerate(id_order)}
 
     col = []
@@ -88,7 +97,7 @@ def create_adjacency_matrix(
 
     matrix = sparse.coo_matrix(
         (np.ones(len(row), dtype=np.uint8), (row, col)),
-        shape=(len(ts_order), len(ts_order)),
+        shape=(len(id_order), len(id_order)),
         dtype=np.uint8,
     )
 

--- a/engine/src/ddr_engine/merit/build.py
+++ b/engine/src/ddr_engine/merit/build.py
@@ -86,7 +86,7 @@ def create_adjacency_matrix(
     col = []
     row = []
 
-    for node in tqdm(ts_order, desc="Creating sparse matrix indices"):
+    for node in tqdm(ts_order, desc="Creating sparse matrix indices", ncols=140, ascii=True):
         if graph.out_degree(node) == 0:
             continue
         id = graph.get_node_data(node)
@@ -196,7 +196,7 @@ def build_gauge_adjacencies(
     store = zarr.storage.LocalStore(root=out_path)
     root = zarr.create_group(store=store)
 
-    for gauge in tqdm(gauge_set.gauges, desc="Creating Gauge COO matrices"):
+    for gauge in tqdm(gauge_set.gauges, desc="Creating Gauge COO matrices", ncols=140, ascii=True):
         staid = gauge.STAID
         origin_comid = gauge.COMID
 

--- a/engine/src/ddr_engine/merit/build.py
+++ b/engine/src/ddr_engine/merit/build.py
@@ -206,10 +206,8 @@ def build_gauge_adjacencies(
 
         if len(subset_comids) == 1:
             print(
-                f"Gauge {str(staid).zfill(8)} (COMID {origin_comid}) is a headwater catchment. Skipping write"
+                f"Gauge {str(staid).zfill(8)} (COMID {origin_comid}) is a headwater catchment (single reach)"
             )
-            root.__delitem__(staid)
-            continue
 
         coo, subset_list = create_subset_coo(subset_comids, merit_mapping, graph, node_indices)
 

--- a/engine/src/ddr_engine/merit/graph.py
+++ b/engine/src/ddr_engine/merit/graph.py
@@ -71,7 +71,7 @@ def build_graph(
     graph = rx.PyDiGraph(check_cycle=False)
     node_indices: dict[int, int] = {}
 
-    for to_comid in tqdm(sorted(upstream_network.keys()), desc="Adding nodes"):
+    for to_comid in tqdm(sorted(upstream_network.keys()), desc="Adding nodes", ncols=140, ascii=True):
         from_comids = upstream_network[to_comid]
         if to_comid not in node_indices:
             node_indices[to_comid] = graph.add_node(to_comid)
@@ -79,7 +79,7 @@ def build_graph(
             if from_comid not in node_indices:
                 node_indices[from_comid] = graph.add_node(from_comid)
 
-    for to_comid, from_comids in tqdm(upstream_network.items(), desc="Adding edges"):
+    for to_comid, from_comids in tqdm(upstream_network.items(), desc="Adding edges", ncols=140, ascii=True):
         for from_comid in from_comids:
             graph.add_edge(node_indices[from_comid], node_indices[to_comid], None)
 

--- a/scripts/summed_q_prime.py
+++ b/scripts/summed_q_prime.py
@@ -208,7 +208,7 @@ def eval_q_prime(
         .streamflow.values.astype(np.float32)
     )
     for i, gauge in tqdm(
-        enumerate(valid_gauges), total=len(valid_gauges), desc="Processing gauges", ncols=140
+        enumerate(valid_gauges), total=len(valid_gauges), desc="Processing gauges", ncols=140, ascii=True
     ):
         if cfg.geodataset == GeoDataset.LYNKER_HYDROFABRIC.value:
             basins: np.ndarray = np.array([f"cat-{_id}" for _id in gages_adjacency[gauge]["order"][:]])

--- a/src/ddr/geodatazoo/merit.py
+++ b/src/ddr/geodatazoo/merit.py
@@ -156,15 +156,23 @@ class Merit(BaseGeoDataset):
 
         coo, _gage_idx, gage_catchment = construct_network_matrix(batch, self.gages_adjacency)
 
-        active_indices = np.unique(np.concatenate([coo.row, coo.col]))
+        edge_indices = (
+            np.unique(np.concatenate([coo.row, coo.col])) if coo.nnz > 0 else np.array([], dtype=int)
+        )
+        gage_indices = np.array(_gage_idx, dtype=int)
+        active_indices = np.unique(np.concatenate([edge_indices, gage_indices]))
         index_mapping = {orig_idx: compressed_idx for compressed_idx, orig_idx in enumerate(active_indices)}
 
-        compressed_rows = np.array([index_mapping[idx] for idx in coo.row])
-        compressed_cols = np.array([index_mapping[idx] for idx in coo.col])
+        if coo.nnz > 0:
+            compressed_rows = np.array([index_mapping[idx] for idx in coo.row])
+            compressed_cols = np.array([index_mapping[idx] for idx in coo.col])
+        else:
+            compressed_rows = np.array([], dtype=int)
+            compressed_cols = np.array([], dtype=int)
 
         compressed_size = len(active_indices)
         compressed_coo = sparse.coo_matrix(
-            (coo.data, (compressed_rows, compressed_cols)),
+            (coo.data[: len(compressed_rows)], (compressed_rows, compressed_cols)),
             shape=(compressed_size, compressed_size),
         )
         compressed_csr = compressed_coo.tocsr()
@@ -177,7 +185,10 @@ class Merit(BaseGeoDataset):
             mask = np.isin(coo.row, _idx)
             local_gage_inflow_idx = np.where(mask)[0]
             original_col_indices = coo.col[local_gage_inflow_idx]
-            compressed_col_indices = np.array([index_mapping[idx] for idx in original_col_indices])
+            if len(original_col_indices) > 0:
+                compressed_col_indices = np.array([index_mapping[idx] for idx in original_col_indices])
+            else:
+                compressed_col_indices = np.array([index_mapping[int(_idx)]])
             outflow_idx.append(compressed_col_indices)
 
         adjacency_matrix, spatial_attributes, normalized_spatial_attributes, flowpath_tensors = (
@@ -383,15 +394,23 @@ class Merit(BaseGeoDataset):
 
         coo, _gage_idx, gage_catchment = construct_network_matrix(batch, self.gages_adjacency)
 
-        active_indices = np.unique(np.concatenate([coo.row, coo.col]))
+        edge_indices = (
+            np.unique(np.concatenate([coo.row, coo.col])) if coo.nnz > 0 else np.array([], dtype=int)
+        )
+        gage_indices = np.array(_gage_idx, dtype=int)
+        active_indices = np.unique(np.concatenate([edge_indices, gage_indices]))
         index_mapping = {orig_idx: compressed_idx for compressed_idx, orig_idx in enumerate(active_indices)}
 
-        compressed_rows = np.array([index_mapping[idx] for idx in coo.row])
-        compressed_cols = np.array([index_mapping[idx] for idx in coo.col])
+        if coo.nnz > 0:
+            compressed_rows = np.array([index_mapping[idx] for idx in coo.row])
+            compressed_cols = np.array([index_mapping[idx] for idx in coo.col])
+        else:
+            compressed_rows = np.array([], dtype=int)
+            compressed_cols = np.array([], dtype=int)
 
         compressed_size = len(active_indices)
         compressed_coo = sparse.coo_matrix(
-            (coo.data, (compressed_rows, compressed_cols)),
+            (coo.data[: len(compressed_rows)], (compressed_rows, compressed_cols)),
             shape=(compressed_size, compressed_size),
         )
         compressed_csr = compressed_coo.tocsr()
@@ -403,7 +422,10 @@ class Merit(BaseGeoDataset):
             mask = np.isin(coo.row, _idx)
             local_gage_inflow_idx = np.where(mask)[0]
             original_col_indices = coo.col[local_gage_inflow_idx]
-            compressed_col_indices = np.array([index_mapping[idx] for idx in original_col_indices])
+            if len(original_col_indices) > 0:
+                compressed_col_indices = np.array([index_mapping[idx] for idx in original_col_indices])
+            else:
+                compressed_col_indices = np.array([index_mapping[int(_idx)]])
             outflow_idx.append(compressed_col_indices)
 
         adjacency_matrix, spatial_attributes, normalized_spatial_attributes, flowpath_tensors = (

--- a/src/ddr/io/builders.py
+++ b/src/ddr/io/builders.py
@@ -100,7 +100,7 @@ def construct_network_matrix(
         rows: list[int] = list(rows_tuple)
         cols: list[int] = list(cols_tuple)
     else:
-        raise ValueError("No coordinate-pairs found. Cannot construct a matrix")
+        rows, cols = [], []
     shape = tuple(_attrs["shape"])
     coo = sparse.coo_matrix(
         (np.ones(len(rows)), (rows, cols)),

--- a/src/ddr/validation/plots.py
+++ b/src/ddr/validation/plots.py
@@ -60,7 +60,7 @@ def plot_time_series(
     plt.plot(
         time_range[warmup:],
         prediction_to_plot,
-        label=f"Routed Streamflow [ΣQ={pred_mass:.1f}, NSE: {nse:.4f}]",
+        label=f"DDR [ΣQ={pred_mass:.1f}, NSE: {nse:.4f}]",
     )
 
     if additional_predictions is not None:

--- a/tests/engine/merit/test_integration.py
+++ b/tests/engine/merit/test_integration.py
@@ -160,8 +160,10 @@ class TestIsolatedCOMIDs:
             geometry=[LineString([(0, 99), (1, 99)])],
             crs="EPSG:4326",
         )
+        import pandas as pd
+
         return gpd.GeoDataFrame(
-            data=mock_merit_fp._append(isolated_row, ignore_index=True),
+            pd.concat([mock_merit_fp, isolated_row], ignore_index=True),
             crs="EPSG:4326",
         )
 
@@ -233,8 +235,10 @@ class TestHeadwaterGaugeAdjacency:
             geometry=[LineString([(0, 99), (1, 99)])],
             crs="EPSG:4326",
         )
+        import pandas as pd
+
         return gpd.GeoDataFrame(
-            data=mock_merit_fp._append(isolated_row, ignore_index=True),
+            pd.concat([mock_merit_fp, isolated_row], ignore_index=True),
             crs="EPSG:4326",
         )
 

--- a/tests/engine/merit/test_integration.py
+++ b/tests/engine/merit/test_integration.py
@@ -2,7 +2,9 @@
 
 import numpy as np
 import pytest
+import zarr
 from ddr_engine.merit import (
+    build_gauge_adjacencies,
     build_graph,
     build_merit_adjacency,
     build_upstream_dict,
@@ -135,3 +137,182 @@ class TestEdgeCases:
         build_merit_adjacency(mock_merit_fp, out_path)
 
         assert out_path.exists()
+
+
+class TestIsolatedCOMIDs:
+    """Tests for isolated COMIDs (single-reach basins with no connections)."""
+
+    @pytest.fixture
+    def fp_with_isolated(self, mock_merit_fp):
+        """Sandbox network plus an isolated COMID 99 with no connections."""
+        import geopandas as gpd
+        from shapely.geometry import LineString
+
+        isolated_row = gpd.GeoDataFrame(
+            {
+                "COMID": [99],
+                "NextDownID": [0],
+                "up1": [0],
+                "up2": [0],
+                "up3": [0],
+                "up4": [0],
+            },
+            geometry=[LineString([(0, 99), (1, 99)])],
+            crs="EPSG:4326",
+        )
+        return gpd.GeoDataFrame(
+            data=mock_merit_fp._append(isolated_row, ignore_index=True),
+            crs="EPSG:4326",
+        )
+
+    def test_isolated_comid_in_order(self, fp_with_isolated):
+        """Isolated COMID should appear in topological order."""
+        matrix, order = create_adjacency_matrix(fp_with_isolated)
+        assert 99 in order
+
+    def test_isolated_comid_matrix_shape(self, fp_with_isolated):
+        """Matrix should be 6x6 (5 connected + 1 isolated)."""
+        matrix, order = create_adjacency_matrix(fp_with_isolated)
+        assert matrix.shape == (6, 6)
+        assert len(order) == 6
+
+    def test_isolated_comid_no_edges(self, fp_with_isolated):
+        """Isolated COMID should have no edges — same 4 edges as sandbox."""
+        matrix, order = create_adjacency_matrix(fp_with_isolated)
+        assert matrix.nnz == 4
+
+    def test_isolated_comid_lower_triangular(self, fp_with_isolated):
+        """Matrix should still be lower triangular."""
+        matrix, _ = create_adjacency_matrix(fp_with_isolated)
+        assert np.all(matrix.row >= matrix.col)
+
+    def test_connected_comids_unchanged(self, fp_with_isolated):
+        """Connected COMIDs should still have correct edges."""
+        matrix, order = create_adjacency_matrix(fp_with_isolated)
+        idx = {comid: i for i, comid in enumerate(order)}
+        dense = matrix.toarray()
+
+        expected_edges = [
+            (30, 10),
+            (30, 20),
+            (50, 30),
+            (50, 40),
+        ]
+        for downstream, upstream in expected_edges:
+            assert dense[idx[downstream], idx[upstream]] == 1
+
+    def test_isolated_comid_zarr_roundtrip(self, tmp_path, fp_with_isolated):
+        """Isolated COMID should survive zarr roundtrip."""
+        out_path = tmp_path / "isolated_test.zarr"
+        build_merit_adjacency(fp_with_isolated, out_path)
+        coo, ts_order = coo_from_zarr(out_path)
+
+        assert 99 in ts_order
+        assert coo.shape == (6, 6)
+        assert coo.nnz == 4
+
+
+class TestHeadwaterGaugeAdjacency:
+    """Tests for build_gauge_adjacencies with headwater gages."""
+
+    @pytest.fixture
+    def fp_with_isolated(self, mock_merit_fp):
+        """Sandbox network plus isolated COMID 99."""
+        import geopandas as gpd
+        from shapely.geometry import LineString
+
+        isolated_row = gpd.GeoDataFrame(
+            {
+                "COMID": [99],
+                "NextDownID": [0],
+                "up1": [0],
+                "up2": [0],
+                "up3": [0],
+                "up4": [0],
+            },
+            geometry=[LineString([(0, 99), (1, 99)])],
+            crs="EPSG:4326",
+        )
+        return gpd.GeoDataFrame(
+            data=mock_merit_fp._append(isolated_row, ignore_index=True),
+            crs="EPSG:4326",
+        )
+
+    @pytest.fixture
+    def merit_zarr_path(self, tmp_path, fp_with_isolated):
+        """Build MERIT adjacency zarr with isolated COMID included."""
+        out_path = tmp_path / "merit_adjacency.zarr"
+        build_merit_adjacency(fp_with_isolated, out_path)
+        return out_path
+
+    def test_headwater_gauge_gets_zarr_group(self, tmp_path, fp_with_isolated, merit_zarr_path):
+        """A gauge at a connected headwater (COMID 10) should produce a zarr subgroup."""
+        from tests.engine.merit.conftest import MockGauge, MockGaugeSet
+
+        gauge_set = MockGaugeSet(gauges=[MockGauge(STAID="00000010", COMID=10)])
+        out_path = tmp_path / "gauge_adj.zarr"
+
+        build_gauge_adjacencies(fp_with_isolated, merit_zarr_path, gauge_set, out_path)
+
+        root = zarr.open_group(store=out_path, mode="r")
+        assert "00000010" in list(root.group_keys())
+
+    def test_headwater_gauge_has_empty_coo(self, tmp_path, fp_with_isolated, merit_zarr_path):
+        """Headwater gauge zarr subgroup should have empty indices (no edges)."""
+        from tests.engine.merit.conftest import MockGauge, MockGaugeSet
+
+        gauge_set = MockGaugeSet(gauges=[MockGauge(STAID="00000010", COMID=10)])
+        out_path = tmp_path / "gauge_adj_empty.zarr"
+
+        build_gauge_adjacencies(fp_with_isolated, merit_zarr_path, gauge_set, out_path)
+
+        root = zarr.open_group(store=out_path, mode="r")
+        gauge_group = root["00000010"]
+        assert gauge_group["indices_0"][:].shape[0] == 0
+        assert gauge_group["indices_1"][:].shape[0] == 0
+        assert len(gauge_group["order"][:]) == 1
+
+    def test_isolated_gauge_gets_zarr_group(self, tmp_path, fp_with_isolated, merit_zarr_path):
+        """A gauge at an isolated COMID (99) should produce a zarr subgroup."""
+        from tests.engine.merit.conftest import MockGauge, MockGaugeSet
+
+        gauge_set = MockGaugeSet(gauges=[MockGauge(STAID="00000099", COMID=99)])
+        out_path = tmp_path / "gauge_adj_isolated.zarr"
+
+        build_gauge_adjacencies(fp_with_isolated, merit_zarr_path, gauge_set, out_path)
+
+        root = zarr.open_group(store=out_path, mode="r")
+        assert "00000099" in list(root.group_keys())
+
+        gauge_group = root["00000099"]
+        assert gauge_group["indices_0"][:].shape[0] == 0
+        assert gauge_group["indices_1"][:].shape[0] == 0
+        assert len(gauge_group["order"][:]) == 1
+        assert gauge_group.attrs["gage_catchment"] == 99
+
+    def test_mixed_gauges_all_present(self, tmp_path, fp_with_isolated, merit_zarr_path):
+        """A batch with connected gauge (50), headwater (10), and isolated (99) should all produce zarr groups."""
+        from tests.engine.merit.conftest import MockGauge, MockGaugeSet
+
+        gauge_set = MockGaugeSet(
+            gauges=[
+                MockGauge(STAID="00000050", COMID=50),
+                MockGauge(STAID="00000010", COMID=10),
+                MockGauge(STAID="00000099", COMID=99),
+            ]
+        )
+        out_path = tmp_path / "gauge_adj_mixed.zarr"
+
+        build_gauge_adjacencies(fp_with_isolated, merit_zarr_path, gauge_set, out_path)
+
+        root = zarr.open_group(store=out_path, mode="r")
+        group_keys = list(root.group_keys())
+        assert "00000050" in group_keys
+        assert "00000010" in group_keys
+        assert "00000099" in group_keys
+
+        # Connected gauge should have edges
+        assert root["00000050"]["indices_0"][:].shape[0] > 0
+        # Headwater/isolated should have no edges
+        assert root["00000010"]["indices_0"][:].shape[0] == 0
+        assert root["00000099"]["indices_0"][:].shape[0] == 0

--- a/zensical.toml
+++ b/zensical.toml
@@ -25,6 +25,7 @@ nav = [
      "usage/train.md",
      "usage/test.md",
      "usage/routing.md",
+     "usage/hot_start.md",
      "usage/summed_q_prime.md",
      "usage/examples.md",
   ]},


### PR DESCRIPTION
## Issue Addressed                                                                                                                  
- flow initialization now computes topologically accumulated upstream discharge instead of using raw local lateral inflow          
  - `(I - N) @ Q = Q'` is the equation for hot-starts where you'll start based on the summed Q` discharge
- Extracted hot-start logic into a standalone, unit-testable function                                                                    
- Added documentation explaining the mechanism          
- Added headwater basins into the engine/ code for training/benchmarking
  - DDR routing will work on headwaters like`Q_{t+1} = C₃·Q_t + C₄·Q'` since there is no inflow

### Description

- Added compute_hotstart_discharge() — a module-level function that solves (I - N) @ Q = q_prime[0] via triangular_sparse_solve to accumulate upstream lateral inflows. Each node gets the sum of all upstream inflows as its initial discharge, rather than just its own local contribution.
- setup_inputs() cold-start branch now calls this function instead of the naive self._discharge_t = self.q_prime[0]. The carry_state=True path (inference batches after the first) is unchanged.
- Updated test_setup_inputs_basic assertion — no longer expects _discharge_t == streamflow[0]; now verifies shape, headwater equality, and that downstream nodes accumulate upstream flow.
- Added TestComputeHotstartDischarge class with 6 tests:
  - test_linear_chain_uniform_inflow — uniform inflow=2 on 5-node chain produces [2, 4, 6, 8, 10]
  - test_linear_chain_nonuniform_inflow — varying inflow [3, 1, 2, 4] produces cumsum [3, 4, 6, 10]
  - test_single_reach — single node returns its own inflow
  - test_clamping — tiny inflows get clamped to discharge_lb
  - test_setup_inputs_uses_hotstart — end-to-end through setup_inputs()
  - test_carry_state_skips_hotstart — carry_state=True preserves existing state

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [X] Documentation update

Other (please specify):

## Checklist

- [X] Branch is up to date with master
- [X] Updated tests or added new tests
- [X] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [ ] Code follows established style and conventions
