### PR TITLE
feat: flow scaling for partial catchment gages

### DIFF
--- a/src/ddr/geodatazoo/dataclasses.py
+++ b/src/ddr/geodatazoo/dataclasses.py
@@ -206,3 +206,4 @@ class RoutingDataclass:
         default=None
     )  # Has to be list[np.ndarray] since idx are ragged arrays
     gage_catchment: list[str] | None = field(default=None)
+    flow_scale: torch.Tensor | None = field(default=None)

--- a/src/ddr/geodatazoo/lynker_hydrofabric.py
+++ b/src/ddr/geodatazoo/lynker_hydrofabric.py
@@ -19,6 +19,7 @@ from ddr.io.builders import (
 )
 from ddr.io.readers import (
     IcechunkUSGSReader,
+    build_flow_scale_tensor,
     fill_nans,
     filter_gages_by_area_threshold,
     naninfmean,
@@ -247,6 +248,14 @@ class LynkerHydrofabric(BaseGeoDataset):
                 )
             ).all(), "Gage WB don't match up with indices"
 
+        gage_compressed_indices = [index_mapping[int(idx)] for idx in _gage_idx]
+        flow_scale = build_flow_scale_tensor(
+            batch=batch,
+            gage_dict=self.obs_reader.gage_dict,
+            gage_compressed_indices=gage_compressed_indices,
+            num_segments=compressed_size,
+        )
+
         adjacency_matrix, spatial_attributes, normalized_spatial_attributes, flowpath_tensors = (
             self._build_common_tensors(compressed_csr, divide_ids, compressed_flowpath_attr)
         )
@@ -272,6 +281,7 @@ class LynkerHydrofabric(BaseGeoDataset):
             divide_ids=divide_ids,
             outflow_idx=outflow_idx,
             gage_catchment=gage_catchment,
+            flow_scale=flow_scale,
         )
 
     def _build_common_tensors(
@@ -497,6 +507,14 @@ class LynkerHydrofabric(BaseGeoDataset):
                 compressed_col_indices = np.array([index_mapping[int(_idx)]])
             outflow_idx.append(compressed_col_indices)
 
+        gage_compressed_indices = [index_mapping[int(idx)] for idx in _gage_idx]
+        flow_scale = build_flow_scale_tensor(
+            batch=batch,
+            gage_dict=self.obs_reader.gage_dict,
+            gage_compressed_indices=gage_compressed_indices,
+            num_segments=compressed_size,
+        )
+
         adjacency_matrix, spatial_attributes, normalized_spatial_attributes, flowpath_tensors = (
             self._build_common_tensors(compressed_csr, divide_ids, compressed_flowpath_attr)
         )
@@ -522,4 +540,5 @@ class LynkerHydrofabric(BaseGeoDataset):
             divide_ids=divide_ids,
             outflow_idx=outflow_idx,
             gage_catchment=gage_catchment,
+            flow_scale=flow_scale,
         )

--- a/src/ddr/geodatazoo/merit.py
+++ b/src/ddr/geodatazoo/merit.py
@@ -20,6 +20,7 @@ from ddr.io.builders import (
 )
 from ddr.io.readers import (
     IcechunkUSGSReader,
+    build_flow_scale_tensor,
     fill_nans,
     filter_gages_by_area_threshold,
     naninfmean,
@@ -217,6 +218,14 @@ class Merit(BaseGeoDataset):
                 compressed_col_indices = np.array([index_mapping[int(_idx)]])
             outflow_idx.append(compressed_col_indices)
 
+        gage_compressed_indices = [index_mapping[int(idx)] for idx in _gage_idx]
+        flow_scale = build_flow_scale_tensor(
+            batch=batch,
+            gage_dict=self.obs_reader.gage_dict,
+            gage_compressed_indices=gage_compressed_indices,
+            num_segments=compressed_size,
+        )
+
         adjacency_matrix, spatial_attributes, normalized_spatial_attributes, flowpath_tensors = (
             self._build_common_tensors(compressed_csr, compressed_merit_ids, compressed_flowpath_attr)
         )
@@ -242,6 +251,7 @@ class Merit(BaseGeoDataset):
             divide_ids=compressed_merit_ids,
             outflow_idx=outflow_idx,
             gage_catchment=gage_catchment,
+            flow_scale=flow_scale,
         )
 
     def _build_common_tensors(
@@ -454,6 +464,14 @@ class Merit(BaseGeoDataset):
                 compressed_col_indices = np.array([index_mapping[int(_idx)]])
             outflow_idx.append(compressed_col_indices)
 
+        gage_compressed_indices = [index_mapping[int(idx)] for idx in _gage_idx]
+        flow_scale = build_flow_scale_tensor(
+            batch=batch,
+            gage_dict=self.obs_reader.gage_dict,
+            gage_compressed_indices=gage_compressed_indices,
+            num_segments=compressed_size,
+        )
+
         adjacency_matrix, spatial_attributes, normalized_spatial_attributes, flowpath_tensors = (
             self._build_common_tensors(compressed_csr, compressed_merit_ids, compressed_flowpath_attr)
         )
@@ -479,4 +497,5 @@ class Merit(BaseGeoDataset):
             divide_ids=compressed_merit_ids,
             outflow_idx=outflow_idx,
             gage_catchment=gage_catchment,
+            flow_scale=flow_scale,
         )

--- a/src/ddr/routing/mmc.py
+++ b/src/ddr/routing/mmc.py
@@ -263,6 +263,9 @@ class MuskingumCunge:
 
         self.q_prime = streamflow.to(self.device)
 
+        if routing_dataclass.flow_scale is not None:
+            self.q_prime = self.q_prime * routing_dataclass.flow_scale.unsqueeze(0).to(self.device)
+
     def _denormalize_spatial_parameters(self, spatial_parameters: dict[str, torch.Tensor]) -> None:
         """Denormalize NN [0,1] outputs to physical parameter bounds with log-space handling."""
         self.spatial_parameters = spatial_parameters

--- a/tests/io/test_flow_scaling.py
+++ b/tests/io/test_flow_scaling.py
@@ -1,0 +1,124 @@
+"""Unit tests for flow scaling pure functions."""
+
+import pytest
+import torch
+
+from ddr.io.readers import build_flow_scale_tensor, compute_flow_scale_factor
+
+
+class TestComputeFlowScaleFactor:
+    """Tests for compute_flow_scale_factor."""
+
+    @pytest.mark.parametrize(
+        "drain, comid_drain, unit_area, expected",
+        [
+            # Negative diff within unit area → fraction < 1
+            (90, 100, 20, 0.5),
+            (95, 100, 20, 0.75),
+            (80, 100, 20, 1.0),  # abs(diff)=20 >= unit_area=20 → 1.0
+            # Positive diff → no scaling
+            (110, 100, 20, 1.0),
+            (100, 100, 20, 1.0),  # diff == 0, >= 0
+            # Zero / negative unit area → 1.0
+            (90, 100, 0, 1.0),
+            (90, 100, -5, 1.0),
+            # abs(diff) > unit area → 1.0
+            (70, 100, 20, 1.0),
+            # Tiny diff
+            (99.9, 100, 20, (20 - 0.1) / 20),
+        ],
+    )
+    def test_core_formula(self, drain, comid_drain, unit_area, expected):
+        result = compute_flow_scale_factor(drain, comid_drain, unit_area)
+        assert result == pytest.approx(expected, abs=1e-9)
+
+    @pytest.mark.parametrize(
+        "drain, comid_drain, unit_area",
+        [
+            (float("nan"), 100, 20),
+            (90, float("nan"), 20),
+            (90, 100, float("nan")),
+            (float("nan"), float("nan"), float("nan")),
+        ],
+    )
+    def test_nan_inputs_return_one(self, drain, comid_drain, unit_area):
+        assert compute_flow_scale_factor(drain, comid_drain, unit_area) == 1.0
+
+
+class TestBuildFlowScaleTensor:
+    """Tests for build_flow_scale_tensor."""
+
+    def _make_gage_dict(self, staids, drains, comid_drains, unit_areas):
+        return {
+            "STAID": staids,
+            "DRAIN_SQKM": drains,
+            "COMID_DRAIN_SQKM": comid_drains,
+            "COMID_UNITAREA_SQKM": unit_areas,
+        }
+
+    def test_correct_shape_and_values(self):
+        gage_dict = self._make_gage_dict(
+            staids=["01000000", "02000000"],
+            drains=[90.0, 50.0],
+            comid_drains=[100.0, 60.0],
+            unit_areas=[20.0, 20.0],
+        )
+        # gage 0 → seg 2, gage 1 → seg 5
+        result = build_flow_scale_tensor(
+            batch=["01000000", "02000000"],
+            gage_dict=gage_dict,
+            gage_compressed_indices=[2, 5],
+            num_segments=8,
+        )
+        assert result.shape == (8,)
+        assert result[2].item() == pytest.approx(0.5)
+        assert result[5].item() == pytest.approx(0.5)
+        # All other segments should be 1.0
+        for i in [0, 1, 3, 4, 6, 7]:
+            assert result[i].item() == 1.0
+
+    def test_missing_metadata_returns_all_ones(self):
+        gage_dict: dict[str, list] = {
+            "STAID": ["01000000"],
+            "DRAIN_SQKM": [90.0],
+            # Missing COMID_DRAIN_SQKM and COMID_UNITAREA_SQKM
+        }
+        result = build_flow_scale_tensor(
+            batch=["01000000"],
+            gage_dict=gage_dict,
+            gage_compressed_indices=[0],
+            num_segments=5,
+        )
+        assert result.shape == (5,)
+        assert torch.all(result == 1.0)
+
+    def test_missing_comid_unitarea_returns_all_ones(self):
+        gage_dict: dict[str, list] = {
+            "STAID": ["01000000"],
+            "DRAIN_SQKM": [90.0],
+            "COMID_DRAIN_SQKM": [100.0],
+            # Missing COMID_UNITAREA_SQKM
+        }
+        result = build_flow_scale_tensor(
+            batch=["01000000"],
+            gage_dict=gage_dict,
+            gage_compressed_indices=[0],
+            num_segments=5,
+        )
+        assert torch.all(result == 1.0)
+
+    def test_gage_not_in_dict_skipped(self):
+        """A STAID in batch that's not in gage_dict should be silently skipped."""
+        gage_dict = self._make_gage_dict(
+            staids=["01000000"],
+            drains=[90.0],
+            comid_drains=[100.0],
+            unit_areas=[20.0],
+        )
+        result = build_flow_scale_tensor(
+            batch=["99999999"],  # not in gage_dict
+            gage_dict=gage_dict,
+            gage_compressed_indices=[0],
+            num_segments=3,
+        )
+        assert torch.all(result == 1.0)

--- a/tests/routing/test_flow_scaling.py
+++ b/tests/routing/test_flow_scaling.py
@@ -1,0 +1,166 @@
+"""Acceptance and chaos tests for flow_scale integration in routing."""
+
+import pytest
+import torch
+
+from ddr.io.readers import build_flow_scale_tensor
+from ddr.routing.mmc import MuskingumCunge
+
+from .test_utils import (
+    create_mock_config,
+    create_mock_routing_dataclass,
+    create_mock_spatial_parameters,
+    create_mock_streamflow,
+)
+
+
+class TestFlowScaleBackwardCompatible:
+    """Acceptance: flow_scale=None leaves q_prime unmodified."""
+
+    def test_flow_scale_none_backward_compatible(self):
+        cfg = create_mock_config()
+        mc = MuskingumCunge(cfg, device="cpu")
+        hf = create_mock_routing_dataclass(num_reaches=10)
+        streamflow = create_mock_streamflow(24, 10)
+        params = create_mock_spatial_parameters(10)
+
+        assert hf.flow_scale is None
+        mc.setup_inputs(hf, streamflow, params)
+        # q_prime should equal the original streamflow (just moved to device)
+        assert torch.allclose(mc.q_prime, streamflow)
+
+
+class TestFlowScaleReducesQPrime:
+    """Acceptance: flow_scale reduces q_prime at the scaled segment."""
+
+    def test_flow_scale_reduces_q_prime_at_segment(self):
+        cfg = create_mock_config()
+        mc = MuskingumCunge(cfg, device="cpu")
+        hf = create_mock_routing_dataclass(num_reaches=10)
+        streamflow = create_mock_streamflow(24, 10)
+        params = create_mock_spatial_parameters(10)
+
+        # Scale segment 2 to 50%
+        flow_scale = torch.ones(10, dtype=torch.float32)
+        flow_scale[2] = 0.5
+        hf.flow_scale = flow_scale
+
+        mc.setup_inputs(hf, streamflow, params)
+
+        # Segment 2 should be halved
+        assert mc.q_prime is not None
+        expected_seg2 = streamflow[:, 2] * 0.5
+        assert torch.allclose(mc.q_prime[:, 2], expected_seg2)
+
+        # Other segments should be untouched
+        for i in [0, 1, 3, 4, 5, 6, 7, 8, 9]:
+            assert torch.allclose(mc.q_prime[:, i], streamflow[:, i])
+
+
+class TestFlowScaleChaos:
+    """Chaos tests: edge cases that shouldn't crash or produce NaN/Inf."""
+
+    def test_near_zero_fraction(self):
+        """Extreme scaling (fraction ~0.005) doesn't produce NaN/Inf."""
+        cfg = create_mock_config()
+        mc = MuskingumCunge(cfg, device="cpu")
+        hf = create_mock_routing_dataclass(num_reaches=5)
+        streamflow = create_mock_streamflow(12, 5)
+        params = create_mock_spatial_parameters(5)
+
+        flow_scale = torch.ones(5, dtype=torch.float32)
+        flow_scale[1] = 0.005
+        hf.flow_scale = flow_scale
+
+        mc.setup_inputs(hf, streamflow, params)
+        assert mc.q_prime is not None
+        assert not torch.isnan(mc.q_prime).any()
+        assert not torch.isinf(mc.q_prime).any()
+        assert torch.allclose(mc.q_prime[:, 1], streamflow[:, 1] * 0.005)
+
+    def test_gage_not_in_dict_skipped(self):
+        """Unknown STAID in batch doesn't crash, returns all-ones."""
+
+        def _make_gage_dict(staids, drains, comid_drains, unit_areas):
+            return {
+                "STAID": staids,
+                "DRAIN_SQKM": drains,
+                "COMID_DRAIN_SQKM": comid_drains,
+                "COMID_UNITAREA_SQKM": unit_areas,
+            }
+
+        gage_dict = _make_gage_dict(
+            staids=["01000000"],
+            drains=[90.0],
+            comid_drains=[100.0],
+            unit_areas=[20.0],
+        )
+        result = build_flow_scale_tensor(
+            batch=["99999999"],
+            gage_dict=gage_dict,
+            gage_compressed_indices=[0],
+            num_segments=5,
+        )
+        assert torch.all(result == 1.0)
+
+    def test_two_catchments_contributing_to_gage(self):
+        """Gage at a confluence: outflow_idx has multiple segment indices but
+        flow_scale only modifies the gage's own catchment segment, leaving
+        upstream contributors at 1.0."""
+
+        def _make_gage_dict(staids, drains, comid_drains, unit_areas):
+            return {
+                "STAID": staids,
+                "DRAIN_SQKM": drains,
+                "COMID_DRAIN_SQKM": comid_drains,
+                "COMID_UNITAREA_SQKM": unit_areas,
+            }
+
+        gage_dict = _make_gage_dict(
+            staids=["01000000"],
+            drains=[90.0],
+            comid_drains=[100.0],
+            unit_areas=[20.0],
+        )
+        # gage_compressed_indices points to the gage's own segment (index 3)
+        # outflow_idx might include [1, 2, 3] (upstream + gage), but flow_scale
+        # only touches the gage's segment
+        result = build_flow_scale_tensor(
+            batch=["01000000"],
+            gage_dict=gage_dict,
+            gage_compressed_indices=[3],
+            num_segments=5,
+        )
+        # Gage segment (3) should be scaled
+        assert result[3].item() == pytest.approx(0.5)
+        # Upstream segments untouched
+        for i in [0, 1, 2, 4]:
+            assert result[i].item() == 1.0
+
+    def test_two_gages_same_segment(self):
+        """Two gages map to the same compressed segment index. Second gage's
+        factor overwrites the first. Test documents this behavior."""
+
+        def _make_gage_dict(staids, drains, comid_drains, unit_areas):
+            return {
+                "STAID": staids,
+                "DRAIN_SQKM": drains,
+                "COMID_DRAIN_SQKM": comid_drains,
+                "COMID_UNITAREA_SQKM": unit_areas,
+            }
+
+        gage_dict = _make_gage_dict(
+            staids=["01000000", "02000000"],
+            drains=[90.0, 95.0],
+            comid_drains=[100.0, 100.0],
+            unit_areas=[20.0, 20.0],
+        )
+        # Both gages map to segment 2
+        result = build_flow_scale_tensor(
+            batch=["01000000", "02000000"],
+            gage_dict=gage_dict,
+            gage_compressed_indices=[2, 2],
+            num_segments=5,
+        )
+        # Second gage (02000000): diff=-5, fraction=(20-5)/20=0.75
+        assert result[2].item() == pytest.approx(0.75)

--- a/tests/routing/test_utils.py
+++ b/tests/routing/test_utils.py
@@ -120,6 +120,7 @@ class MockRoutingDataclass:
         # mock gauge outflows
         self.outflow_idx = [np.array([-1])]  # Picking two values as there are two gages in obs
         self.gage_catchment = ["wb-1"]
+        self.flow_scale = None
 
 
 def create_mock_routing_dataclass(num_reaches: int = 10, device: str = "cpu") -> MockRoutingDataclass:


### PR DESCRIPTION
## Summary

- Adds Q' (lateral inflow) scaling at gage segments where the gage drains only a fraction of its mapped catchment, correcting area mismatch before routing enters the Muskingum-Cunge equation
- Computes a per-segment `flow_scale` tensor from `DRAIN_SQKM`, `COMID_DRAIN_SQKM`, and `COMID_UNITAREA_SQKM` gage metadata — when metadata is absent, returns all-ones (no-op)
- Applied in `_set_network_context()` as a single broadcast multiply on `q_prime`, keeping the routing loop untouched

## Formula

```
diff = DRAIN_SQKM - COMID_DRAIN_SQKM

IF diff < 0 AND abs(diff) < COMID_UNITAREA_SQKM:
    fraction = (COMID_UNITAREA_SQKM - abs(diff)) / COMID_UNITAREA_SQKM
ELSE:
    fraction = 1.0  (no scaling)
```

Example: COMID_DRAIN=100, DRAIN=90, UNIT_AREA=20 → fraction = (20-10)/20 = **0.5**

## Changes

| File | Change |
|------|--------|
| `src/ddr/io/readers.py` | `compute_flow_scale_factor()` (pure math) + `build_flow_scale_tensor()` (builds per-segment tensor) |
| `src/ddr/geodatazoo/dataclasses.py` | `flow_scale` field on `RoutingDataclass` (default `None`, backward-compatible) |
| `src/ddr/geodatazoo/merit.py` | Compute + pass `flow_scale` in `_collate_gages` and `_build_routing_data_gages` |
| `src/ddr/geodatazoo/lynker_hydrofabric.py` | Same as merit.py |
| `src/ddr/routing/mmc.py` | Apply `flow_scale` to `q_prime` in `_set_network_context` |
| `tests/routing/test_utils.py` | `flow_scale = None` on mock |
| `tests/io/test_flow_scaling.py` | **NEW** — 17 unit tests (formula, NaN guards, missing metadata, unknown gage) |
| `tests/routing/test_flow_scaling.py` | **NEW** — 6 acceptance + chaos tests (backward compat, segment reduction, near-zero fraction, confluence, overwrite) |

## Not touched

- `_build_routing_data_all_catchments()` / `_build_routing_data_target_catchments()` — no gages, no scaling
- `torch_mc.py` — scaling is in mmc.py at setup time
- `forward()` / `route_timestep()` — routing loop unchanged
- Config / validation — no toggle; automatic via metadata presence

## Test plan

- [x] `pytest tests/io/test_flow_scaling.py -v` — 17 passed
- [x] `pytest tests/routing/test_flow_scaling.py -v` — 6 passed
- [x] `pytest tests/ --ignore=tests/benchmarks -v` — 376 passed, 1 skipped, 0 failures
- [ ] Verify on a real gauged network that scaled gages produce lower Q' and closer area match

🤖 Generated with [Claude Code](https://claude.com/claude-code)