### PR TITLE
feat: LSTM-only leakance, remove KAN-based path 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,7 +199,7 @@ examples/eval/*.zarr
 examples/scratch
 
 # claude
-Claude.md
+CLAUDE.md
 .claude/
 
 # misc

--- a/benchmarks/config/benchmark.yaml
+++ b/benchmarks/config/benchmark.yaml
@@ -55,11 +55,24 @@ kan:
     - q_spatial
     - top_width
     - side_slope
-    - K_D
-    - d_gw
-    - leakance_factor
   grid: 50
   k: 2
+
+leakance_lstm:
+  hidden_size: 64
+  num_layers: 1
+  dropout: 0.5
+  input_var_names:
+    - SoilGrids1km_clay
+    - aridity
+    - meanelevation
+    - meanP
+    - NDVI
+    - meanslope
+    - log10_uparea
+    - SoilGrids1km_sand
+    - ETPOT_Hargr
+    - Porosity
 
 # === DiffRoute-specific configuration ===
 diffroute:

--- a/benchmarks/config/example_benchmark.yaml
+++ b/benchmarks/config/example_benchmark.yaml
@@ -126,6 +126,25 @@ kan:
   grid: 50                        # B-spline grid resolution
   k: 2                            # B-spline order
 
+# --- Leakance LSTM (GW-SW exchange) ---
+# LSTM that predicts time-varying K_D, d_gw, leakance_factor from daily Q'
+# and static catchment attributes. Only used when params.use_leakance is true.
+leakance_lstm:
+  hidden_size: 64
+  num_layers: 1
+  dropout: 0.5
+  input_var_names:
+    - SoilGrids1km_clay
+    - aridity
+    - meanelevation
+    - meanP
+    - NDVI
+    - meanslope
+    - log10_uparea
+    - SoilGrids1km_sand
+    - ETPOT_Hargr
+    - Porosity
+
 # =============================================================================
 # DiffRoute-specific configuration
 # =============================================================================

--- a/benchmarks/scripts/benchmark.py
+++ b/benchmarks/scripts/benchmark.py
@@ -12,7 +12,7 @@ from ddr_benchmarks.validation import validate_benchmark_config
 from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig
 
-from ddr import dmc, kan, streamflow
+from ddr import dmc, kan, leakance_lstm, streamflow
 from ddr._version import __version__
 
 log = logging.getLogger(__name__)
@@ -46,6 +46,16 @@ def main(cfg: DictConfig) -> None:
             seed=config.seed,
             device=config.device,
         )
+        leakance_nn = None
+        if config.params.use_leakance:
+            leakance_nn = leakance_lstm(
+                input_var_names=config.leakance_lstm.input_var_names,
+                hidden_size=config.leakance_lstm.hidden_size,
+                num_layers=config.leakance_lstm.num_layers,
+                dropout=config.leakance_lstm.dropout,
+                seed=config.seed,
+                device=config.device,
+            )
         routing_model = dmc(cfg=config, device=config.device)
         flow = streamflow(config)
 
@@ -56,6 +66,7 @@ def main(cfg: DictConfig) -> None:
             nn=nn,
             diffroute_cfg=diffroute_cfg,
             summed_q_prime_path=benchmark_cfg.summed_q_prime,
+            leakance_nn=leakance_nn,
         )
 
     except KeyboardInterrupt:

--- a/scripts/router.py
+++ b/scripts/router.py
@@ -191,7 +191,7 @@ def main(cfg: DictConfig) -> None:
             device=config.device,
         )
         leakance_nn = None
-        if config.params.use_leakance and config.leakance_lstm is not None:
+        if config.params.use_leakance:
             leakance_nn = leakance_lstm(
                 input_var_names=config.leakance_lstm.input_var_names,
                 hidden_size=config.leakance_lstm.hidden_size,

--- a/scripts/router.py
+++ b/scripts/router.py
@@ -14,7 +14,7 @@ from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig
 from torch.utils.data import DataLoader, SequentialSampler
 
-from ddr import dmc, kan, streamflow
+from ddr import dmc, kan, leakance_lstm, streamflow
 from ddr._version import __version__
 from ddr.scripts_utils import compute_daily_runoff, load_checkpoint
 from ddr.validation import Config, validate_config
@@ -22,16 +22,25 @@ from ddr.validation import Config, validate_config
 log = logging.getLogger(__name__)
 
 
-def route_trained_model(cfg: Config, flow: streamflow, routing_model: dmc, nn: kan) -> None:
+def route_trained_model(
+    cfg: Config,
+    flow: streamflow,
+    routing_model: dmc,
+    nn: kan,
+    leakance_nn: leakance_lstm | None = None,
+) -> None:
     """Route a trained model over a specific amount of defined catchments"""
     dataset = cfg.geodataset.get_dataset_class(cfg=cfg)
 
     if cfg.experiment.checkpoint:
-        load_checkpoint(nn, cfg.experiment.checkpoint, torch.device(cfg.device))
+        load_checkpoint(nn, cfg.experiment.checkpoint, torch.device(cfg.device), leakance_nn=leakance_nn)
     else:
         log.warning("Creating new spatial model for evaluation.")
 
     nn = nn.eval()
+    if leakance_nn is not None:
+        leakance_nn.cache_states = True
+        leakance_nn = leakance_nn.eval()
     sampler = SequentialSampler(
         data_source=dataset,
     )
@@ -85,6 +94,17 @@ def route_trained_model(cfg: Config, flow: streamflow, routing_model: dmc, nn: k
                 "streamflow": streamflow_predictions,
                 "carry_state": i > 0,
             }
+
+            if leakance_nn is not None:
+                T_hourly = streamflow_predictions.shape[0]
+                T_daily = T_hourly // 24
+                daily_q_prime = streamflow_predictions[: T_daily * 24].reshape(T_daily, 24, -1).mean(dim=1)
+                leakance_params = leakance_nn(
+                    q_prime=daily_q_prime,
+                    attributes=routing_dataclass.normalized_spatial_attributes.to(cfg.device),
+                )
+                dmc_kwargs["leakance_params"] = leakance_params
+
             dmc_output = routing_model(**dmc_kwargs)
             predictions[:, dataset.dates.hourly_indices] = dmc_output["runoff"].cpu().numpy()
 
@@ -170,9 +190,21 @@ def main(cfg: DictConfig) -> None:
             seed=config.seed,
             device=config.device,
         )
+        leakance_nn = None
+        if config.params.use_leakance and config.leakance_lstm is not None:
+            leakance_nn = leakance_lstm(
+                input_var_names=config.leakance_lstm.input_var_names,
+                hidden_size=config.leakance_lstm.hidden_size,
+                num_layers=config.leakance_lstm.num_layers,
+                dropout=config.leakance_lstm.dropout,
+                seed=config.seed,
+                device=config.device,
+            )
         routing_model = dmc(cfg=config, device=cfg.device)
         flow = streamflow(config)
-        route_trained_model(cfg=config, flow=flow, routing_model=routing_model, nn=nn)
+        route_trained_model(
+            cfg=config, flow=flow, routing_model=routing_model, nn=nn, leakance_nn=leakance_nn
+        )
 
     except KeyboardInterrupt:
         log.info("Keyboard interrupt received")

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -158,7 +158,7 @@ def main(cfg: DictConfig) -> None:
             device=config.device,
         )
         leakance_nn = None
-        if config.params.use_leakance and config.leakance_lstm is not None:
+        if config.params.use_leakance:
             leakance_nn = leakance_lstm(
                 input_var_names=config.leakance_lstm.input_var_names,
                 hidden_size=config.leakance_lstm.hidden_size,

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -14,7 +14,7 @@ from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig
 from torch.utils.data import DataLoader, SequentialSampler
 
-from ddr import dmc, kan, streamflow
+from ddr import dmc, kan, leakance_lstm, streamflow
 from ddr._version import __version__
 from ddr.scripts_utils import compute_daily_runoff, load_checkpoint
 from ddr.validation import Config, Metrics, utils, validate_config
@@ -22,16 +22,25 @@ from ddr.validation import Config, Metrics, utils, validate_config
 log = logging.getLogger(__name__)
 
 
-def test(cfg: Config, flow: streamflow, routing_model: dmc, nn: kan) -> None:
+def test(
+    cfg: Config,
+    flow: streamflow,
+    routing_model: dmc,
+    nn: kan,
+    leakance_nn: leakance_lstm | None = None,
+) -> None:
     """Do model evaluation and get performance metrics."""
     dataset = cfg.geodataset.get_dataset_class(cfg=cfg)
 
     if cfg.experiment.checkpoint:
-        load_checkpoint(nn, cfg.experiment.checkpoint, torch.device(cfg.device))
+        load_checkpoint(nn, cfg.experiment.checkpoint, torch.device(cfg.device), leakance_nn=leakance_nn)
     else:
         log.warning("Creating new spatial model for evaluation.")
 
     nn = nn.eval()
+    if leakance_nn is not None:
+        leakance_nn.cache_states = True
+        leakance_nn = leakance_nn.eval()
     sampler = SequentialSampler(
         data_source=dataset,
     )
@@ -70,6 +79,17 @@ def test(cfg: Config, flow: streamflow, routing_model: dmc, nn: kan) -> None:
                 "streamflow": streamflow_predictions,
                 "carry_state": i > 0,
             }
+
+            if leakance_nn is not None:
+                T_hourly = streamflow_predictions.shape[0]
+                T_daily = T_hourly // 24
+                daily_q_prime = streamflow_predictions[: T_daily * 24].reshape(T_daily, 24, -1).mean(dim=1)
+                leakance_params = leakance_nn(
+                    q_prime=daily_q_prime,
+                    attributes=routing_dataclass.normalized_spatial_attributes.to(cfg.device),
+                )
+                dmc_kwargs["leakance_params"] = leakance_params
+
             dmc_output = routing_model(**dmc_kwargs)
             predictions[:, dataset.dates.hourly_indices] = dmc_output["runoff"].cpu().numpy()
 
@@ -137,9 +157,19 @@ def main(cfg: DictConfig) -> None:
             seed=config.seed,
             device=config.device,
         )
+        leakance_nn = None
+        if config.params.use_leakance and config.leakance_lstm is not None:
+            leakance_nn = leakance_lstm(
+                input_var_names=config.leakance_lstm.input_var_names,
+                hidden_size=config.leakance_lstm.hidden_size,
+                num_layers=config.leakance_lstm.num_layers,
+                dropout=config.leakance_lstm.dropout,
+                seed=config.seed,
+                device=config.device,
+            )
         routing_model = dmc(cfg=config, device=cfg.device)
         flow = streamflow(config)
-        test(cfg=config, flow=flow, routing_model=routing_model, nn=nn)
+        test(cfg=config, flow=flow, routing_model=routing_model, nn=nn, leakance_nn=leakance_nn)
 
     except KeyboardInterrupt:
         log.info("Keyboard interrupt received")

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -189,7 +189,7 @@ def main(cfg: DictConfig) -> None:
             device=config.device,
         )
         leakance_nn = None
-        if config.params.use_leakance and config.leakance_lstm is not None:
+        if config.params.use_leakance:
             leakance_nn = leakance_lstm(
                 input_var_names=config.leakance_lstm.input_var_names,
                 hidden_size=config.leakance_lstm.hidden_size,

--- a/src/ddr/__init__.py
+++ b/src/ddr/__init__.py
@@ -2,7 +2,7 @@ from . import validation
 from ._version import __version__
 from .io import functions as ddr_functions
 from .io.readers import StreamflowReader as streamflow
-from .nn import kan
+from .nn import kan, leakance_lstm
 from .routing.torch_mc import dmc
 
-__all__ = ["__version__", "dmc", "streamflow", "ddr_functions", "kan", "validation"]
+__all__ = ["__version__", "dmc", "streamflow", "ddr_functions", "kan", "leakance_lstm", "validation"]

--- a/src/ddr/nn/__init__.py
+++ b/src/ddr/nn/__init__.py
@@ -1,3 +1,4 @@
 from .kan import kan
+from .leakance_lstm import leakance_lstm
 
-__all__ = ["kan"]
+__all__ = ["kan", "leakance_lstm"]

--- a/src/ddr/nn/leakance_lstm.py
+++ b/src/ddr/nn/leakance_lstm.py
@@ -1,0 +1,106 @@
+import logging
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+log = logging.getLogger(__name__)
+
+
+class leakance_lstm(torch.nn.Module):
+    """An LSTM for time-varying leakance (GW-SW exchange) parameter prediction.
+
+    Follows the CudnnLstmModel/LstmModel architecture from generic_deltamodel:
+    Linear(nx, hidden) -> ReLU -> LSTM(hidden, hidden) -> Linear(hidden, ny) -> Sigmoid
+
+    Concatenates a dynamic signal (q_prime) with static catchment attributes
+    at each timestep, producing time-varying K_D, d_gw, and leakance_factor in [0,1].
+    """
+
+    def __init__(
+        self,
+        input_var_names: list[str],
+        hidden_size: int,
+        num_layers: int,
+        dropout: float,
+        seed: int,
+        device: int | str = "cpu",
+    ):
+        super().__init__()
+        self.input_size = len(input_var_names) + 1  # +1 for q_prime
+        self.hidden_size = hidden_size
+        self.learnable_parameters = ["K_D", "d_gw", "leakance_factor"]
+        self.output_size = len(self.learnable_parameters)
+
+        torch.manual_seed(seed)
+
+        # Input encoding (generic_deltamodel CudnnLstmModel pattern)
+        self.linear_in = torch.nn.Linear(self.input_size, hidden_size, device=device)
+
+        # LSTM operates on encoded hidden_size features
+        self.lstm = torch.nn.LSTM(
+            input_size=hidden_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            dropout=dropout if num_layers > 1 else 0.0,
+        )
+
+        # Output projection
+        self.linear_out = torch.nn.Linear(hidden_size, self.output_size, device=device)
+
+        # Hidden state management (generic_deltamodel pattern)
+        # Training: cache_states=False -> hn/cn stay None, zeros created each batch
+        # Inference: cache_states=True -> hn/cn carried over (detached) between batches
+        self.cache_states: bool = False
+        self.hn: torch.Tensor | None = None
+        self.cn: torch.Tensor | None = None
+
+    def forward(self, *args: Any, **kwargs: Any) -> dict[str, torch.Tensor]:
+        """Forward pass of the LSTM.
+
+        Parameters
+        ----------
+        q_prime : torch.Tensor
+            Daily lateral inflow, shape (T_daily, N). Passed via kwargs.
+        attributes : torch.Tensor
+            Normalized static catchment attributes, shape (N, num_attrs). Passed via kwargs.
+
+        Returns
+        -------
+        dict[str, torch.Tensor]
+            Dictionary with K_D, d_gw, leakance_factor each shape (T_daily, N) in [0, 1].
+        """
+        q_prime: torch.Tensor = kwargs["q_prime"]  # [T_daily, N]
+        attributes: torch.Tensor = kwargs["attributes"]
+        T, N = q_prime.shape
+
+        # Concat daily q_prime + static attrs at each timestep
+        attrs_expanded = attributes.unsqueeze(0).expand(T, -1, -1)
+        _x = torch.cat([q_prime.unsqueeze(-1), attrs_expanded], dim=-1)  # [T, N, input_size]
+
+        # Input encoding (CudnnLstmModel pattern: Linear -> ReLU)
+        _x = F.relu(self.linear_in(_x))  # [T, N, hidden_size]
+
+        # LSTM forward — hn/cn are None during training (zeros created internally)
+        h0 = (
+            (self.hn.to(_x.device), self.cn.to(_x.device))
+            if self.hn is not None and self.cn is not None
+            else None
+        )
+        lstm_out, (hn, cn) = self.lstm(_x, h0)  # [T, N, hidden_size]
+
+        # State management (generic_deltamodel pattern)
+        # Training (cache_states=False): states stay None, reset each batch
+        # Inference (cache_states=True): states carried forward (detached)
+        if self.cache_states:
+            self.hn = hn.detach()
+            self.cn = cn.detach()
+
+        # Output projection + sigmoid
+        _x = self.linear_out(lstm_out)  # [T, N, 3]
+        _x = torch.sigmoid(_x)
+
+        outputs: dict[str, torch.Tensor] = {}
+        for idx, key in enumerate(self.learnable_parameters):
+            outputs[key] = _x[:, :, idx]
+        return outputs

--- a/src/ddr/nn/leakance_lstm.py
+++ b/src/ddr/nn/leakance_lstm.py
@@ -43,6 +43,7 @@ class leakance_lstm(torch.nn.Module):
             hidden_size=hidden_size,
             num_layers=num_layers,
             dropout=dropout if num_layers > 1 else 0.0,
+            device=device,
         )
 
         # Output projection

--- a/src/ddr/routing/mmc.py
+++ b/src/ddr/routing/mmc.py
@@ -370,24 +370,6 @@ class MuskingumCunge:
         else:
             self.side_slope = routing_dataclass.side_slope.to(self.device).to(torch.float32)
 
-        if self.use_leakance and self.cfg.leakance_lstm is None:
-            # KAN mode: leakance params come from spatial_parameters
-            self.K_D = denormalize(
-                value=spatial_parameters["K_D"],
-                bounds=self.parameter_bounds["K_D"],
-                log_space="K_D" in log_space_params,
-            )
-            self.d_gw = denormalize(
-                value=spatial_parameters["d_gw"],
-                bounds=self.parameter_bounds["d_gw"],
-                log_space="d_gw" in log_space_params,
-            )
-            self.leakance_factor = denormalize(
-                value=spatial_parameters["leakance_factor"],
-                bounds=self.parameter_bounds["leakance_factor"],
-                log_space="leakance_factor" in log_space_params,
-            )
-
     def setup_leakance_params(self, leakance_params: dict[str, torch.Tensor]) -> None:
         """Denormalize and store time-varying leakance params from LSTM.
 

--- a/src/ddr/routing/mmc.py
+++ b/src/ddr/routing/mmc.py
@@ -255,11 +255,16 @@ class MuskingumCunge:
         self.epoch = 0
         self.mini_batch = 0
 
-        # Leakance parameters
+        # Leakance parameters (static, from KAN)
         self.use_leakance: bool = cfg.params.use_leakance
         self.K_D: torch.Tensor | None = None
         self.d_gw: torch.Tensor | None = None
         self.leakance_factor: torch.Tensor | None = None
+
+        # Time-varying leakance parameters (from LSTM, daily resolution)
+        self._K_D_t: torch.Tensor | None = None
+        self._d_gw_t: torch.Tensor | None = None
+        self._leakance_factor_t: torch.Tensor | None = None
 
         # Leakance diagnostic accumulators (populated during forward())
         self._zeta_sum: torch.Tensor | None = None
@@ -365,7 +370,8 @@ class MuskingumCunge:
         else:
             self.side_slope = routing_dataclass.side_slope.to(self.device).to(torch.float32)
 
-        if self.use_leakance:
+        if self.use_leakance and self.cfg.leakance_lstm is None:
+            # KAN mode: leakance params come from spatial_parameters
             self.K_D = denormalize(
                 value=spatial_parameters["K_D"],
                 bounds=self.parameter_bounds["K_D"],
@@ -381,6 +387,26 @@ class MuskingumCunge:
                 bounds=self.parameter_bounds["leakance_factor"],
                 log_space="leakance_factor" in log_space_params,
             )
+
+    def setup_leakance_params(self, leakance_params: dict[str, torch.Tensor]) -> None:
+        """Denormalize and store time-varying leakance params from LSTM.
+
+        Parameters
+        ----------
+        leakance_params : dict[str, torch.Tensor]
+            Dict with K_D, d_gw, leakance_factor each shape (T_daily, N) in [0,1].
+            Stored as daily tensors; mapped to hourly timesteps in forward().
+        """
+        log_space = self.cfg.params.log_space_parameters
+        self._K_D_t = denormalize(leakance_params["K_D"], self.parameter_bounds["K_D"], "K_D" in log_space)
+        self._d_gw_t = denormalize(
+            leakance_params["d_gw"], self.parameter_bounds["d_gw"], "d_gw" in log_space
+        )
+        self._leakance_factor_t = denormalize(
+            leakance_params["leakance_factor"],
+            self.parameter_bounds["leakance_factor"],
+            "leakance_factor" in log_space,
+        )
 
     def _init_discharge_state(self, carry_state: bool) -> None:
         """Cold-start via topological accumulation, or carry from previous batch."""
@@ -481,6 +507,15 @@ class MuskingumCunge:
                 self.q_prime[timestep - 1],
                 min=self.cfg.params.attribute_minimums["discharge"],
             )
+
+            # Map hourly timestep to daily index for LSTM leakance params
+            if self.use_leakance and self._K_D_t is not None:
+                assert self._d_gw_t is not None
+                assert self._leakance_factor_t is not None
+                day_idx = (timestep - 1) // 24
+                self.K_D = self._K_D_t[day_idx]
+                self.d_gw = self._d_gw_t[day_idx]
+                self.leakance_factor = self._leakance_factor_t[day_idx]
 
             q_t1 = self.route_timestep(q_prime_clamp=q_prime_clamp, mapper=mapper)
 

--- a/src/ddr/routing/torch_mc.py
+++ b/src/ddr/routing/torch_mc.py
@@ -179,6 +179,11 @@ class dmc(torch.nn.Module):
             carry_state=carry_state,
         )
 
+        # Setup time-varying leakance params from LSTM (if provided)
+        leakance_params = kwargs.get("leakance_params", None)
+        if leakance_params is not None:
+            self.routing_engine.setup_leakance_params(leakance_params)
+
         # Update compatibility attributes
         self.network = self.routing_engine.network
         self.n = self.routing_engine.n

--- a/src/ddr/scripts_utils.py
+++ b/src/ddr/scripts_utils.py
@@ -46,6 +46,7 @@ def load_checkpoint(
     nn: torch.nn.Module,
     checkpoint_path: str | Path,
     device: str | torch.device,
+    leakance_nn: torch.nn.Module | None = None,
 ) -> dict:
     """Load DDR checkpoint, apply state_dict to model. Returns full state dict.
 
@@ -57,6 +58,8 @@ def load_checkpoint(
         Path to the .pt checkpoint file.
     device : str | torch.device
         Device to map tensors to.
+    leakance_nn : torch.nn.Module | None, optional
+        The leakance LSTM model to load weights into, by default None.
 
     Returns
     -------
@@ -70,6 +73,14 @@ def load_checkpoint(
     for key in state_dict.keys():
         state_dict[key] = state_dict[key].to(device)
     nn.load_state_dict(state_dict)
+
+    if leakance_nn is not None and "leakance_nn_state_dict" in state:
+        log.info("Loading leakance_nn from checkpoint")
+        leakance_state = state["leakance_nn_state_dict"]
+        for key in leakance_state.keys():
+            leakance_state[key] = leakance_state[key].to(device)
+        leakance_nn.load_state_dict(leakance_state)
+
     return state
 
 

--- a/src/ddr/validation/utils.py
+++ b/src/ddr/validation/utils.py
@@ -17,6 +17,7 @@ def save_state(
     optimizer: nn.Module,
     name: str,
     saved_model_path: Path,
+    leakance_nn: nn.Module | None = None,
 ) -> None:
     """Save model state
 
@@ -30,10 +31,10 @@ def save_state(
         The MLP model
     optimizer : nn.Module
         The optimizer
-    loss_idx_value : int
-        The loss index value
     name: str
         The name of the file we're saving
+    leakance_nn : nn.Module | None, optional
+        The leakance LSTM model, by default None
     """
     mlp_state_dict = {key: value.cpu() for key, value in mlp.state_dict().items()}
     cpu_optimizer_state_dict: dict[str, Any] = {}
@@ -63,6 +64,10 @@ def save_state(
         "rng_state": torch.get_rng_state(),
         "data_generator_state": generator.get_state(),
     }
+    if leakance_nn is not None:
+        state["leakance_nn_state_dict"] = {
+            key: value.cpu() for key, value in leakance_nn.state_dict().items()
+        }
     if torch.cuda.is_available():
         state["cuda_rng_state"] = torch.cuda.get_rng_state()
     if mini_batch == -1:

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -435,6 +435,9 @@ def create_ddr_config():
             "input_var_names": ["mock"],
             "learnable_parameters": ["n", "q_spatial", "top_width", "side_slope"],
         },
+        "leakance_lstm": {
+            "input_var_names": ["mock"],
+        },
         "s3_region": "us-east-2",
         "device": "cpu",
     }

--- a/tests/benchmarks/test_benchmark_config.py
+++ b/tests/benchmarks/test_benchmark_config.py
@@ -76,6 +76,9 @@ class TestBenchmarkConfig:
                 "grid": 5,
                 "k": 3,
             },
+            leakance_lstm={
+                "input_var_names": ["slope"],
+            },
         )
 
     def test_construction(self, _minimal_ddr_config) -> None:

--- a/tests/nn/test_leakance_lstm.py
+++ b/tests/nn/test_leakance_lstm.py
@@ -1,0 +1,158 @@
+"""Tests for the leakance_lstm module."""
+
+import pytest
+import torch
+
+from ddr.nn.leakance_lstm import leakance_lstm
+
+
+@pytest.fixture
+def model() -> leakance_lstm:
+    """Create a leakance_lstm instance for testing."""
+    return leakance_lstm(
+        input_var_names=["attr1", "attr2", "attr3"],
+        hidden_size=32,
+        num_layers=1,
+        dropout=0.0,
+        seed=42,
+        device="cpu",
+    )
+
+
+@pytest.fixture
+def sample_inputs() -> dict[str, torch.Tensor]:
+    """Create sample inputs for the LSTM."""
+    T_daily = 10
+    N = 5
+    return {
+        "q_prime": torch.rand(T_daily, N),
+        "attributes": torch.rand(N, 3),  # 3 attrs matching input_var_names
+    }
+
+
+class TestLeakanceLstmOutput:
+    """Test output shape, range, and keys."""
+
+    def test_output_shape(self, model: leakance_lstm, sample_inputs: dict[str, torch.Tensor]) -> None:
+        """Test that each output param has shape (T_daily, N)."""
+        outputs = model(**sample_inputs)
+        T, N = sample_inputs["q_prime"].shape
+        for key in ["K_D", "d_gw", "leakance_factor"]:
+            assert outputs[key].shape == (T, N), f"{key} shape {outputs[key].shape} != ({T}, {N})"
+
+    def test_output_range(self, model: leakance_lstm, sample_inputs: dict[str, torch.Tensor]) -> None:
+        """Test that outputs are in [0, 1] (sigmoid)."""
+        outputs = model(**sample_inputs)
+        for key in ["K_D", "d_gw", "leakance_factor"]:
+            assert outputs[key].min() >= 0.0, f"{key} min {outputs[key].min()} < 0"
+            assert outputs[key].max() <= 1.0, f"{key} max {outputs[key].max()} > 1"
+
+    def test_output_keys(self, model: leakance_lstm, sample_inputs: dict[str, torch.Tensor]) -> None:
+        """Test that output dict keys match learnable_parameters."""
+        outputs = model(**sample_inputs)
+        assert set(outputs.keys()) == {"K_D", "d_gw", "leakance_factor"}
+
+    def test_no_nan_or_inf(self, model: leakance_lstm, sample_inputs: dict[str, torch.Tensor]) -> None:
+        """Test that outputs contain no NaN or Inf values."""
+        outputs = model(**sample_inputs)
+        for key, val in outputs.items():
+            assert not torch.isnan(val).any(), f"{key} contains NaN"
+            assert not torch.isinf(val).any(), f"{key} contains Inf"
+
+
+class TestLeakanceLstmGradient:
+    """Test gradient flow through the LSTM."""
+
+    def test_gradient_flow(self, model: leakance_lstm, sample_inputs: dict[str, torch.Tensor]) -> None:
+        """Test that gradients flow from loss back through LSTM weights."""
+        outputs = model(**sample_inputs)
+        loss = sum(v.sum() for v in outputs.values())
+        loss.backward()
+
+        # Check that linear_in, lstm, and linear_out all have gradients
+        assert model.linear_in.weight.grad is not None, "linear_in should have gradients"
+        assert model.linear_out.weight.grad is not None, "linear_out should have gradients"
+        for name, param in model.lstm.named_parameters():
+            if param.requires_grad:
+                assert param.grad is not None, f"LSTM param {name} should have gradients"
+
+
+class TestLeakanceLstmStateManagement:
+    """Test cache_states behavior."""
+
+    def test_cache_states_false_no_hidden_carry(
+        self, model: leakance_lstm, sample_inputs: dict[str, torch.Tensor]
+    ) -> None:
+        """Test that with cache_states=False, hidden states stay None between calls."""
+        model.cache_states = False
+        model(**sample_inputs)
+        assert model.hn is None, "hn should be None when cache_states=False"
+        assert model.cn is None, "cn should be None when cache_states=False"
+
+    def test_cache_states_true_preserves_hidden(
+        self, model: leakance_lstm, sample_inputs: dict[str, torch.Tensor]
+    ) -> None:
+        """Test that with cache_states=True, hidden states are preserved (detached)."""
+        model.cache_states = True
+        model(**sample_inputs)
+        assert model.hn is not None, "hn should be set when cache_states=True"
+        assert model.cn is not None, "cn should be set when cache_states=True"
+        assert not model.hn.requires_grad, "cached hn should be detached"
+        assert not model.cn.requires_grad, "cached cn should be detached"
+
+    def test_cache_states_true_hidden_changes_between_calls(
+        self, model: leakance_lstm, sample_inputs: dict[str, torch.Tensor]
+    ) -> None:
+        """Test that cached hidden states evolve between forward calls."""
+        model.cache_states = True
+        model(**sample_inputs)
+        assert model.hn is not None
+        hn1 = model.hn.clone()
+
+        model(**sample_inputs)
+        assert model.hn is not None
+        hn2 = model.hn.clone()
+
+        assert not torch.allclose(hn1, hn2), "Hidden state should change between sequential calls"
+
+
+class TestLeakanceLstmInit:
+    """Test initialization edge cases."""
+
+    def test_input_size_includes_q_prime(self) -> None:
+        """Test that input_size = len(input_var_names) + 1 for q_prime."""
+        m = leakance_lstm(
+            input_var_names=["a", "b"],
+            hidden_size=16,
+            num_layers=1,
+            dropout=0.0,
+            seed=0,
+            device="cpu",
+        )
+        assert m.input_size == 3  # 2 attrs + 1 q_prime
+
+    def test_multi_layer_lstm(self) -> None:
+        """Test that multi-layer LSTM with dropout works."""
+        m = leakance_lstm(
+            input_var_names=["a"],
+            hidden_size=16,
+            num_layers=3,
+            dropout=0.5,
+            seed=0,
+            device="cpu",
+        )
+        # Should run without error
+        outputs = m(q_prime=torch.rand(5, 4), attributes=torch.rand(4, 1))
+        assert outputs["K_D"].shape == (5, 4)
+
+    def test_single_layer_no_dropout(self) -> None:
+        """Test that single-layer LSTM has dropout=0 regardless of config."""
+        m = leakance_lstm(
+            input_var_names=["a"],
+            hidden_size=16,
+            num_layers=1,
+            dropout=0.5,  # Should be overridden to 0.0
+            seed=0,
+            device="cpu",
+        )
+        assert m.lstm.dropout == 0.0

--- a/tests/routing/test_utils.py
+++ b/tests/routing/test_utils.py
@@ -246,50 +246,6 @@ def create_mock_config_with_leakance() -> Config:
     return config
 
 
-def create_mock_spatial_parameters_with_leakance(
-    num_reaches: int, device: str = "cpu"
-) -> dict[str, torch.Tensor]:
-    """Create mock spatial parameters with leakance params for testing.
-
-    Parameters
-    ----------
-    num_reaches : int
-        Number of reaches
-    device : str, optional
-        Device for tensors, by default 'cpu'
-
-    Returns
-    -------
-    Dict[str, torch.Tensor]
-        Mock spatial parameters (normalized values between 0 and 1)
-    """
-    return {
-        "n": torch.rand(num_reaches, device=device),
-        "q_spatial": torch.rand(num_reaches, device=device),
-        "K_D": torch.rand(num_reaches, device=device),
-        "d_gw": torch.rand(num_reaches, device=device),
-        "leakance_factor": torch.rand(num_reaches, device=device),
-    }
-
-
-def create_mock_nn_with_leakance() -> kan:
-    """Create a mock KAN with leakance parameters for testing."""
-    return kan(
-        input_var_names=[
-            "mean.impervious",
-            "mean.elevation",
-            "mean.smcmax_soil_layers_stag=1",
-        ],
-        learnable_parameters=["n", "q_spatial", "p_spatial", "K_D", "d_gw", "leakance_factor"],
-        hidden_size=11,
-        num_hidden_layers=1,
-        grid=3,
-        k=3,
-        seed=42,
-        device="cpu",
-    )
-
-
 def create_mock_config_with_leakance_lstm() -> Config:
     """Create a mock configuration with LSTM-based leakance enabled for testing."""
     cfg = {

--- a/tests/routing/test_utils.py
+++ b/tests/routing/test_utils.py
@@ -59,6 +59,9 @@ def create_mock_config() -> Config:
                 "mock",
             ],
         },
+        "leakance_lstm": {
+            "input_var_names": ["mock"],
+        },
         "s3_region": "us-east-1",
         "device": "cpu",
     }
@@ -231,7 +234,10 @@ def create_mock_config_with_leakance() -> Config:
             "input_var_names": [
                 "mock",
             ],
-            "learnable_parameters": ["n", "q_spatial", "K_D", "d_gw", "leakance_factor"],
+            "learnable_parameters": ["n", "q_spatial"],
+        },
+        "leakance_lstm": {
+            "input_var_names": ["mock"],
         },
         "s3_region": "us-east-1",
         "device": "cpu",

--- a/tests/validation/test_configs.py
+++ b/tests/validation/test_configs.py
@@ -22,6 +22,9 @@ def _minimal_config_dict(**overrides):
         "kan": {
             "input_var_names": ["slope", "length"],
         },
+        "leakance_lstm": {
+            "input_var_names": ["slope", "length"],
+        },
     }
     base.update(overrides)
     return base


### PR DESCRIPTION
## Issue Addressed

Replace KAN-based static leakance with LSTM-based time-varying leakance for GW-SW exchange parameter prediction, and make the LSTM config always required when leakance is enabled.                                                                                   
                                                                                                                                     
## Description                                                                                                                        
- Added leakance_lstm nn.Module (src/ddr/nn/leakance_lstm.py) — Linear→ReLU→LSTM→Linear→Sigmoid producing time-varying K_D, d_gw, leakance_factor in [0,1]
- Made Config.leakance_lstm non-optional (LeakanceLstm instead of LeakanceLstm | None), eliminating the KAN-based leakance code path
- Removed KAN-mode leakance denormalization block from mmc.py (cfg.leakance_lstm is None branch)
- Added setup_leakance_params() for daily LSTM tensors and _compute_zeta() for GW-SW exchange computation
- Simplified script conditionals from if config.params.use_leakance and config.leakance_lstm is not None to if config.params.use_leakance
- Wired LSTM into training, testing, and routing loops with checkpoint save/load support
- Removed dead test helpers (create_mock_nn_with_leakance, create_mock_spatial_parameters_with_leakance)
- All test config factories updated to include required leakance_lstm section
- Fixed missing device=device on torch.nn.LSTM constructor in leakance_lstm.py
