### PR TITLE
Revert to v0.5.0 baseline, remove unstable features

### DIFF
--- a/benchmarks/src/ddr_benchmarks/benchmark.py
+++ b/benchmarks/src/ddr_benchmarks/benchmark.py
@@ -234,6 +234,48 @@ def run_diffroute_benchmark(
     return output
 
 
+def build_headwater_mask(
+    gages_adjacency_path: str,
+    gage_ids: np.ndarray,
+) -> NDArray[np.bool_]:
+    """Boolean mask where True = non-headwater (keep).
+
+    Headwater gages have zero edges (empty ``indices_0``) in the
+    gages_adjacency zarr store, meaning they are single-reach
+    catchments with no upstream connectivity.
+
+    Parameters
+    ----------
+    gages_adjacency_path : str
+        Path to gages_adjacency zarr store.
+    gage_ids : np.ndarray
+        Array of gage IDs to check.
+
+    Returns
+    -------
+    NDArray[np.bool_]
+        Boolean mask aligned with *gage_ids*; True for non-headwater
+        gages that should be kept in evaluation.
+    """
+    gages_adj = read_zarr(Path(gages_adjacency_path))
+    mask = np.ones(len(gage_ids), dtype=bool)
+    num_headwater = 0
+    num_missing = 0
+    for idx, gage_id in enumerate(gage_ids):
+        if gage_id not in gages_adj:
+            mask[idx] = False
+            num_missing += 1
+            continue
+        if len(gages_adj[gage_id]["indices_0"][:]) == 0:
+            mask[idx] = False
+            num_headwater += 1
+    log.info(
+        f"Headwater filter: {int(mask.sum())}/{len(gage_ids)} gages kept "
+        f"({num_headwater} headwater, {num_missing} missing)"
+    )
+    return mask
+
+
 def load_summed_q_prime(
     summed_q_prime_path: str,
     gage_ids: np.ndarray,
@@ -731,18 +773,15 @@ def benchmark(
                 num_hourly=len(dataset.dates.hourly_time_range),
             )
 
-    # === Filter to gages DiffRoute actually routed (apples-to-apples) ===
-    if diffroute_enabled:
-        routed_mask = ~np.isnan(diffroute_predictions[:, 0])
-        num_excluded = int((~routed_mask).sum())
-        log.info(
-            f"Filtering to {int(routed_mask.sum())}/{len(all_gage_ids)} gages "
-            f"({num_excluded} headwater/skipped gages excluded for apples-to-apples comparison)"
-        )
-        all_gage_ids = all_gage_ids[routed_mask]
-        observations = observations[routed_mask]
-        ddr_predictions = ddr_predictions[routed_mask]
-        diffroute_predictions = diffroute_predictions[routed_mask]
+    # === Always filter headwater gages for consistent evaluation ===
+    assert cfg.data_sources.gages_adjacency is not None, (
+        "gages_adjacency path required for headwater filtering"
+    )
+    non_headwater = build_headwater_mask(cfg.data_sources.gages_adjacency, all_gage_ids)
+    all_gage_ids = all_gage_ids[non_headwater]
+    observations = observations[non_headwater]
+    ddr_predictions = ddr_predictions[non_headwater]
+    diffroute_predictions = diffroute_predictions[non_headwater]
 
     # === EVALUATION (same as test.py) ===
     num_days = len(ddr_predictions[0][13 : (-11 + cfg.params.tau)]) // 24


### PR DESCRIPTION
## Summary

- Reverts the codebase to the stable `73c692f` baseline (pre-leakance, pre-reservoir, pre-GNN node processor)
- Removes 11 experimental commits (#130–#141) that introduced training instability (NaN gradients)
- Ports `build_headwater_mask()` to always filter headwater gages from benchmark evaluation (not just when DiffRoute is enabled)

### What was removed and why

| Commits | Feature | Reason for removal |
|---|---|---|
| #130–#135 | Leakance (GW-SW exchange) | Caused NaN during training; parameter showed no learning |
| #136 | Multi-component hydrograph loss | Experimental, not validated |
| #137 | Mass-conservative interpolation | Experimental |
| #138–#139 | Level-pool reservoirs, learnable Muskingum X | Reservoir routing not working |
| #140 | Updated orifice coefficient | Depends on removed reservoir code |
| #141 | GNN node processor | `_signed_log` on near-zero discharge at timestep 1 produces extreme values (~±18) that destabilize LayerNorm, causing NaN gradients immediately at epoch 1 |

### What was added

- `build_headwater_mask()` in `benchmarks/src/ddr_benchmarks/benchmark.py` — unconditionally filters headwater gages from all evaluation (DDR + DiffRoute), replacing the old DiffRoute-only `~np.isnan()` proxy

## Test plan

- [x] `pytest tests/` — 438 passed, 0 failures
- [ ] Verify training runs without NaN on MERIT dataset
- [ ] Verify benchmark evaluation excludes headwater gages

🤖 Generated with [Claude Code](https://claude.com/claude-code)