### PR TITLE
Phase 1: KAN bias correction foundation (#144)

### DIFF
--- a/src/ddr/nn/__init__.py
+++ b/src/ddr/nn/__init__.py
@@ -1,3 +1,4 @@
 from .kan import kan
+from .temporal_phi_kan import TemporalPhiKAN
 
-__all__ = ["kan"]
+__all__ = ["TemporalPhiKAN", "kan"]

--- a/src/ddr/nn/temporal_phi_kan.py
+++ b/src/ddr/nn/temporal_phi_kan.py
@@ -1,0 +1,125 @@
+"""Temporal φ-KAN for bias correction of lateral inflows.
+
+A small KAN that corrects Q' using flow magnitude and seasonal context.
+By Kolmogorov-Arnold theory, the correction decomposes as:
+
+  φ(Q', sin_m, cos_m) = Σ_q Φ_q( ψ_{q,Q'}(Q') + ψ_{q,sin}(sin_m) + ψ_{q,cos}(cos_m) )
+
+Each ψ is a plottable 1D B-spline curve — fully interpretable.
+"""
+
+import logging
+import math
+
+import torch
+import torch.nn as nn
+from kan import KAN
+
+from ddr.validation.configs import BiasCorrection
+from ddr.validation.enums import PhiInputs
+
+log = logging.getLogger(__name__)
+
+_INPUT_DIM = {
+    PhiInputs.STATIC: 1,
+    PhiInputs.MONTHLY: 3,
+    PhiInputs.FORCING: 2,
+    PhiInputs.RANDOM: 3,
+}
+
+
+class TemporalPhiKAN(nn.Module):
+    """Small KAN that corrects Q' using flow magnitude and seasonal context.
+
+    Parameters
+    ----------
+    cfg : BiasCorrection
+        Bias correction configuration specifying phi_inputs mode and KAN hyperparameters.
+    seed : int
+        Random seed for reproducibility (from top-level Config.seed).
+    device : int | str
+        Compute device (from top-level Config.device).
+    """
+
+    def __init__(self, cfg: BiasCorrection, seed: int, device: int | str = "cpu"):
+        super().__init__()
+        self.phi_inputs = cfg.phi_inputs
+        self.input_dim = _INPUT_DIM[cfg.phi_inputs]
+
+        self.phi_kan = KAN(
+            [self.input_dim, cfg.phi_hidden_size, 1],
+            grid=cfg.phi_grid,
+            k=cfg.phi_k,
+            seed=seed,
+            device=device,
+        )
+
+    def forward(
+        self,
+        q_prime: torch.Tensor,
+        month: torch.Tensor | None = None,
+        forcing: torch.Tensor | None = None,
+        grid_bounds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Bias-correct lateral inflows.
+
+        Parameters
+        ----------
+        q_prime : (T, N)
+            Raw lateral inflow from dHBV2.
+        month : (T,), optional
+            Month of year as float [1, 12]. Required for MONTHLY mode.
+        forcing : (T, N), optional
+            Forcing variable values. Required for FORCING mode.
+        grid_bounds : (N, 2), optional
+            Per-node [min, max] from Spatial KAN for normalization.
+
+        Returns
+        -------
+        q_corrected : (T, N)
+            Bias-corrected lateral inflow.
+        """
+        T, N = q_prime.shape
+
+        # Normalize Q' per-node using Spatial KAN's grid bounds
+        if grid_bounds is not None:
+            grid_min = grid_bounds[:, 0]  # (N,)
+            grid_max = grid_bounds[:, 1]  # (N,)
+            q_norm = (q_prime - grid_min) / (grid_max - grid_min + 1e-8)  # (T, N)
+        else:
+            q_norm = q_prime
+
+        # Build input tensor based on mode
+        if self.phi_inputs == PhiInputs.STATIC:
+            phi_input = q_norm.unsqueeze(-1)  # (T, N, 1)
+
+        elif self.phi_inputs == PhiInputs.MONTHLY:
+            assert month is not None, "month tensor required for MONTHLY mode"
+            two_pi_month = 2.0 * math.pi * month / 12.0  # (T,)
+            sin_month = torch.sin(two_pi_month).unsqueeze(1).expand(T, N)  # (T, N)
+            cos_month = torch.cos(two_pi_month).unsqueeze(1).expand(T, N)  # (T, N)
+            phi_input = torch.stack([q_norm, sin_month, cos_month], dim=-1)  # (T, N, 3)
+
+        elif self.phi_inputs == PhiInputs.FORCING:
+            assert forcing is not None, "forcing tensor required for FORCING mode"
+            phi_input = torch.stack([q_norm, forcing], dim=-1)  # (T, N, 2)
+
+        elif self.phi_inputs == PhiInputs.RANDOM:
+            rand1 = torch.rand(T, N, device=q_prime.device)
+            rand2 = torch.rand(T, N, device=q_prime.device)
+            phi_input = torch.stack([q_norm, rand1, rand2], dim=-1)  # (T, N, 3)
+
+        else:
+            raise ValueError(f"Unknown phi_inputs mode: {self.phi_inputs}")
+
+        # Flatten (T, N, input_dim) → (T*N, input_dim), run KAN, reshape back
+        phi_input_flat = phi_input.reshape(T * N, self.input_dim)
+        q_corrected_norm = self.phi_kan(phi_input_flat).reshape(T, N)  # (T, N)
+
+        # Denormalize back to physical units
+        if grid_bounds is not None:
+            q_corrected = q_corrected_norm * (grid_max - grid_min) + grid_min
+        else:
+            q_corrected = q_corrected_norm
+
+        return torch.clamp(q_corrected, min=1e-6)

--- a/src/ddr/validation/__init__.py
+++ b/src/ddr/validation/__init__.py
@@ -1,13 +1,16 @@
 from . import utils
-from .configs import Config, GeoDataset, Mode, validate_config
+from .configs import BiasCorrection, Config, GeoDataset, Mode, validate_config
+from .enums import PhiInputs
 from .metrics import Metrics
 from .plots import plot_box_fig, plot_cdf, plot_drainage_area_boxplots, plot_gauge_map, plot_time_series
 
 __all__ = [
+    "BiasCorrection",
     "Config",
     "Metrics",
     "Mode",
     "GeoDataset",
+    "PhiInputs",
     "plot_time_series",
     "plot_box_fig",
     "plot_cdf",

--- a/src/ddr/validation/__init__.py
+++ b/src/ddr/validation/__init__.py
@@ -1,6 +1,7 @@
 from . import utils
 from .configs import BiasCorrection, Config, GeoDataset, Mode, validate_config
 from .enums import PhiInputs
+from .losses import kge_loss, mass_balance_loss
 from .metrics import Metrics
 from .plots import plot_box_fig, plot_cdf, plot_drainage_area_boxplots, plot_gauge_map, plot_time_series
 
@@ -11,6 +12,8 @@ __all__ = [
     "Mode",
     "GeoDataset",
     "PhiInputs",
+    "kge_loss",
+    "mass_balance_loss",
     "plot_time_series",
     "plot_box_fig",
     "plot_cdf",

--- a/src/ddr/validation/configs.py
+++ b/src/ddr/validation/configs.py
@@ -9,7 +9,7 @@ from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig, OmegaConf
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
-from ddr.validation.enums import GeoDataset, Mode
+from ddr.validation.enums import GeoDataset, Mode, PhiInputs
 
 log = logging.getLogger(__name__)
 
@@ -188,6 +188,44 @@ class ExperimentConfig(BaseModel):
         return check_path(str(v))
 
 
+class BiasCorrection(BaseModel):
+    """Configuration for KAN-based bias correction of lateral inflows"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(default=False, description="Whether to enable bias correction")
+    phi_inputs: PhiInputs = Field(
+        default=PhiInputs.MONTHLY,
+        description="Input type for the temporal phi-KAN",
+    )
+    forcing_var: str | None = Field(
+        default=None,
+        description="Forcing variable name (required when phi_inputs='forcing')",
+    )
+    phi_hidden_size: int = Field(default=5, description="Hidden layer size for the phi-KAN")
+    phi_grid: int = Field(default=8, description="Grid size for phi-KAN B-spline basis")
+    phi_k: int = Field(default=3, description="B-spline order for phi-KAN layers")
+    lambda_mass: float = Field(
+        default=0.5,
+        description="Weight for mass balance loss relative to KGE loss",
+    )
+    lambda_anneal: bool = Field(
+        default=False,
+        description="Whether to anneal lambda_mass over training epochs",
+    )
+    use_kge_loss: bool = Field(
+        default=True,
+        description="Whether to use KGE loss (True) or MSE loss (False) when bias is enabled",
+    )
+
+    @model_validator(mode="after")
+    def validate_forcing_var(self) -> "BiasCorrection":
+        """Validate that forcing_var is set when phi_inputs is 'forcing'"""
+        if self.phi_inputs == PhiInputs.FORCING and self.forcing_var is None:
+            raise ValueError("forcing_var must be set when phi_inputs='forcing'")
+        return self
+
+
 class Config(BaseModel):
     """The base level configuration for the dMC (differentiable Muskingum-Cunge) model"""
 
@@ -205,6 +243,10 @@ class Config(BaseModel):
     mode: Mode = Field(description="Operating mode: training, testing, or routing")
     params: Params = Field(description="Physical and numerical parameters for the routing model")
     kan: Kan = Field(description="Architecture and configuration settings for the Kolmogorov-Arnold Network")
+    bias: BiasCorrection = Field(
+        default_factory=BiasCorrection,
+        description="Configuration for KAN-based bias correction of lateral inflows",
+    )
     np_seed: int = Field(default=1, description="Random seed for NumPy operations to ensure reproducibility")
     seed: int = Field(default=0, description="Random seed for PyTorch operations to ensure reproducibility")
     device: int | str = Field(

--- a/src/ddr/validation/enums.py
+++ b/src/ddr/validation/enums.py
@@ -14,6 +14,15 @@ class Mode(StrEnum):
     ROUTING = "routing"
 
 
+class PhiInputs(StrEnum):
+    """The type of inputs for the temporal phi-KAN bias correction"""
+
+    STATIC = "static"
+    MONTHLY = "monthly"
+    FORCING = "forcing"
+    RANDOM = "random"
+
+
 class GeoDataset(StrEnum):
     """The geospatial dataset used for predictions and routing"""
 

--- a/src/ddr/validation/losses.py
+++ b/src/ddr/validation/losses.py
@@ -1,0 +1,84 @@
+"""Differentiable loss functions for KAN bias correction training.
+
+mass_balance_loss: gives φ-KAN direct gradients (bypasses MC routing).
+kge_loss: Kling-Gupta Efficiency loss that flows through MC routing.
+"""
+
+import torch
+
+
+def mass_balance_loss(
+    q_corrected: torch.Tensor,
+    target: torch.Tensor,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Mass balance (ρ) loss — gives φ direct gradients bypassing MC.
+
+    MC conserves mass, so total volume at gauge equals total injected volume
+    upstream. ρ_g = AUC_pred_g / AUC_obs_g. Loss = mean((ρ - 1)²).
+
+    Parameters
+    ----------
+    q_corrected : (G, T)
+        Bias-corrected discharge at gauge locations.
+    target : (G, T)
+        Observed discharge at gauge locations.
+    eps : float
+        Small constant to prevent division by zero.
+
+    Returns
+    -------
+    loss : scalar tensor
+    """
+    auc_pred = q_corrected.sum(dim=1)  # (G,)
+    auc_obs = target.sum(dim=1)  # (G,)
+    rho = auc_pred / (auc_obs + eps)
+    return ((rho - 1.0) ** 2).mean()
+
+
+def kge_loss(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Differentiable KGE loss.
+
+    KGE = 1 - sqrt((r-1)² + (α-1)² + (β-1)²)
+    Loss = mean(sqrt((r-1)² + (α-1)² + (β-1)² + eps))
+
+    The eps inside the sqrt prevents NaN gradients at the ideal point.
+    The eps in denominators prevents division by zero for constant series.
+
+    Parameters
+    ----------
+    pred : (G, T)
+        Predicted discharge at gauge locations.
+    target : (G, T)
+        Observed discharge at gauge locations.
+    eps : float
+        Stabilization constant.
+
+    Returns
+    -------
+    loss : scalar tensor
+    """
+    mu_pred = pred.mean(dim=1)  # (G,)
+    mu_obs = target.mean(dim=1)  # (G,)
+    sigma_pred = pred.std(dim=1, correction=0)  # (G,)
+    sigma_obs = target.std(dim=1, correction=0)  # (G,)
+
+    # Correlation
+    pred_anom = pred - mu_pred.unsqueeze(1)
+    obs_anom = target - mu_obs.unsqueeze(1)
+    cov = (pred_anom * obs_anom).mean(dim=1)  # (G,)
+    r = cov / (sigma_pred * sigma_obs + eps)  # (G,)
+
+    # Variability ratio
+    alpha = sigma_pred / (sigma_obs + eps)  # (G,)
+
+    # Bias ratio
+    beta = mu_pred / (mu_obs + eps)  # (G,)
+
+    # Euclidean distance from ideal (1, 1, 1)
+    ed = torch.sqrt((r - 1) ** 2 + (alpha - 1) ** 2 + (beta - 1) ** 2 + eps)  # (G,)
+    return ed.mean()

--- a/tests/nn/test_temporal_phi_kan.py
+++ b/tests/nn/test_temporal_phi_kan.py
@@ -1,0 +1,126 @@
+"""Tests for ddr.nn.temporal_phi_kan — temporal φ-KAN bias correction."""
+
+import math
+
+import torch
+
+from ddr.nn.temporal_phi_kan import TemporalPhiKAN
+from ddr.validation.configs import BiasCorrection
+from ddr.validation.enums import PhiInputs
+
+
+class TestTemporalPhiKAN:
+    """Tests for the TemporalPhiKAN module."""
+
+    def _make_phi_kan(self, phi_inputs: PhiInputs = PhiInputs.MONTHLY) -> TemporalPhiKAN:
+        cfg = BiasCorrection(phi_inputs=phi_inputs)
+        return TemporalPhiKAN(cfg=cfg, seed=42, device="cpu")
+
+    def test_monthly_output_shape(self) -> None:
+        model = self._make_phi_kan(PhiInputs.MONTHLY)
+        T, N = 24, 10
+        q_prime = torch.rand(T, N)
+        month = torch.full((T,), 6.0)
+        output = model(q_prime, month=month)
+
+        assert output.shape == (T, N)
+
+    def test_static_output_shape(self) -> None:
+        model = self._make_phi_kan(PhiInputs.STATIC)
+        T, N = 24, 10
+        q_prime = torch.rand(T, N)
+        output = model(q_prime)
+
+        assert output.shape == (T, N)
+
+    def test_forcing_output_shape(self) -> None:
+        cfg = BiasCorrection(phi_inputs=PhiInputs.FORCING, forcing_var="precip")
+        model = TemporalPhiKAN(cfg=cfg, seed=42, device="cpu")
+        T, N = 24, 10
+        q_prime = torch.rand(T, N)
+        forcing = torch.rand(T, N)
+        output = model(q_prime, forcing=forcing)
+
+        assert output.shape == (T, N)
+
+    def test_random_output_shape(self) -> None:
+        model = self._make_phi_kan(PhiInputs.RANDOM)
+        T, N = 24, 10
+        q_prime = torch.rand(T, N)
+        output = model(q_prime)
+
+        assert output.shape == (T, N)
+
+    def test_non_negative_output(self) -> None:
+        model = self._make_phi_kan(PhiInputs.MONTHLY)
+        T, N = 48, 5
+        q_prime = torch.rand(T, N) * 0.01  # very small values
+        month = torch.full((T,), 1.0)
+        output = model(q_prime, month=month)
+
+        assert (output >= 1e-6).all(), "Output has values below clamp threshold"
+
+    def test_gradient_flow(self) -> None:
+        model = self._make_phi_kan(PhiInputs.MONTHLY)
+        T, N = 12, 5
+        q_prime = torch.rand(T, N, requires_grad=True)
+        month = torch.full((T,), 3.0)
+        output = model(q_prime, month=month)
+
+        loss = output.sum()
+        loss.backward()
+
+        has_grad = False
+        for p in model.parameters():
+            if p.grad is not None:
+                has_grad = True
+                break
+        assert has_grad, "No parameter received gradients"
+
+    def test_deterministic_eval(self) -> None:
+        model = self._make_phi_kan(PhiInputs.MONTHLY)
+        model.eval()
+        T, N = 12, 5
+        q_prime = torch.rand(T, N)
+        month = torch.full((T,), 7.0)
+
+        with torch.no_grad():
+            out1 = model(q_prime, month=month)
+            out2 = model(q_prime, month=month)
+
+        assert torch.equal(out1, out2)
+
+    def test_with_grid_bounds(self) -> None:
+        model = self._make_phi_kan(PhiInputs.MONTHLY)
+        T, N = 12, 5
+        q_prime = torch.rand(T, N) * 100
+        month = torch.full((T,), 6.0)
+        grid_bounds = torch.tensor([[0.0, 100.0]] * N)
+
+        output = model(q_prime, month=month, grid_bounds=grid_bounds)
+        assert output.shape == (T, N)
+
+    def test_without_grid_bounds(self) -> None:
+        model = self._make_phi_kan(PhiInputs.STATIC)
+        T, N = 12, 5
+        q_prime = torch.rand(T, N)
+
+        output = model(q_prime, grid_bounds=None)
+        assert output.shape == (T, N)
+
+    def test_sin_cos_encoding(self) -> None:
+        """Verify sin/cos month encoding produces expected values."""
+        # January: month=1 → sin(2π/12) ≈ 0.5, cos(2π/12) ≈ 0.866
+        month = torch.tensor([1.0])
+        two_pi_month = 2.0 * math.pi * month / 12.0
+        sin_val = torch.sin(two_pi_month)
+        cos_val = torch.cos(two_pi_month)
+
+        assert abs(sin_val.item() - 0.5) < 0.01
+        assert abs(cos_val.item() - 0.866) < 0.01
+
+        # April: month=4 → sin(2π*4/12) ≈ 0.866, cos ≈ -0.5
+        month = torch.tensor([4.0])
+        two_pi_month = 2.0 * math.pi * month / 12.0
+        assert abs(torch.sin(two_pi_month).item() - 0.866) < 0.01
+        assert abs(torch.cos(two_pi_month).item() - (-0.5)) < 0.01

--- a/tests/nn/test_temporal_phi_kan.py
+++ b/tests/nn/test_temporal_phi_kan.py
@@ -108,6 +108,20 @@ class TestTemporalPhiKAN:
         output = model(q_prime, grid_bounds=None)
         assert output.shape == (T, N)
 
+    def test_monotonicity(self) -> None:
+        """Output should increase when Q' increases (other inputs fixed)."""
+        model = self._make_phi_kan(PhiInputs.STATIC)
+        model.eval()
+        N = 10
+        q_low = torch.full((1, N), 0.2)
+        q_high = torch.full((1, N), 0.8)
+        with torch.no_grad():
+            out_low = model(q_low)
+            out_high = model(q_high)
+        assert (out_high >= out_low).all(), (
+            f"Expected monotonic increase: out_low={out_low}, out_high={out_high}"
+        )
+
     def test_sin_cos_encoding(self) -> None:
         """Verify sin/cos month encoding produces expected values."""
         # January: month=1 → sin(2π/12) ≈ 0.5, cos(2π/12) ≈ 0.866

--- a/tests/validation/test_configs.py
+++ b/tests/validation/test_configs.py
@@ -5,7 +5,7 @@ import torch
 from omegaconf import OmegaConf
 from pydantic import ValidationError
 
-from ddr.validation.configs import Config, Params, validate_config
+from ddr.validation.configs import BiasCorrection, Config, Params, validate_config
 
 
 def _minimal_config_dict(**overrides):
@@ -220,3 +220,81 @@ class TestValidateConfig:
         config = validate_config(dc, save_config=False)
         assert isinstance(config, Config)
         assert config.name == "test_run"
+
+
+class TestBiasCorrection:
+    """Test BiasCorrection config."""
+
+    def test_default_bias_disabled(self) -> None:
+        """BiasCorrection() defaults to enabled=False."""
+        bc = BiasCorrection()
+        assert bc.enabled is False
+        assert bc.phi_inputs == "monthly"
+        assert bc.lambda_mass == 0.5
+
+    def test_config_without_bias_gets_default(self, tmp_path) -> None:
+        """Config without bias key gets BiasCorrection(enabled=False)."""
+        gpkg = tmp_path / "test.gpkg"
+        gpkg.touch()
+        adj = tmp_path / "adj"
+        adj.mkdir()
+
+        d = _minimal_config_dict()
+        d["data_sources"]["geospatial_fabric_gpkg"] = str(gpkg)
+        d["data_sources"]["conus_adjacency"] = str(adj)
+
+        config = Config(**d)
+        assert config.bias.enabled is False
+
+    def test_config_with_bias_enabled(self, tmp_path) -> None:
+        """Config with bias.enabled=True is accepted."""
+        gpkg = tmp_path / "test.gpkg"
+        gpkg.touch()
+        adj = tmp_path / "adj"
+        adj.mkdir()
+
+        d = _minimal_config_dict()
+        d["data_sources"]["geospatial_fabric_gpkg"] = str(gpkg)
+        d["data_sources"]["conus_adjacency"] = str(adj)
+        d["bias"] = {"enabled": True}
+
+        config = Config(**d)
+        assert config.bias.enabled is True
+        assert config.bias.phi_inputs == "monthly"
+
+    def test_bias_extra_fields_rejected(self) -> None:
+        """extra='forbid' rejects unknown fields in BiasCorrection."""
+        with pytest.raises(ValidationError):
+            BiasCorrection(enabled=True, unknown_field="bad")
+
+    def test_bias_invalid_phi_inputs_rejected(self) -> None:
+        """Invalid phi_inputs string raises ValidationError."""
+        with pytest.raises(ValidationError):
+            BiasCorrection(phi_inputs="invalid_mode")
+
+    def test_forcing_requires_forcing_var(self) -> None:
+        """phi_inputs='forcing' without forcing_var raises."""
+        with pytest.raises(ValidationError, match="forcing_var"):
+            BiasCorrection(phi_inputs="forcing", forcing_var=None)
+
+    def test_forcing_with_var_valid(self) -> None:
+        """phi_inputs='forcing' with forcing_var is accepted."""
+        bc = BiasCorrection(phi_inputs="forcing", forcing_var="precip")
+        assert bc.forcing_var == "precip"
+
+    def test_validate_config_with_bias(self, tmp_path) -> None:
+        """validate_config round-trip with bias section."""
+        gpkg = tmp_path / "test.gpkg"
+        gpkg.touch()
+        adj = tmp_path / "adj"
+        adj.mkdir()
+
+        d = _minimal_config_dict(device="cpu")
+        d["data_sources"]["geospatial_fabric_gpkg"] = str(gpkg)
+        d["data_sources"]["conus_adjacency"] = str(adj)
+        d["bias"] = {"enabled": True, "phi_inputs": "static"}
+
+        dc = OmegaConf.create(d)
+        config = validate_config(dc, save_config=False)
+        assert config.bias.enabled is True
+        assert config.bias.phi_inputs == "static"

--- a/tests/validation/test_losses.py
+++ b/tests/validation/test_losses.py
@@ -1,0 +1,80 @@
+"""Tests for ddr.validation.losses — differentiable loss functions."""
+
+import torch
+
+from ddr.validation.losses import kge_loss, mass_balance_loss
+
+
+class TestMassBalanceLoss:
+    """Test mass balance (ρ) loss."""
+
+    def test_perfect_volume_match(self) -> None:
+        """ρ=1 for identical series → loss=0."""
+        pred = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+        target = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+        loss = mass_balance_loss(pred, target)
+        assert loss.item() < 1e-10
+
+    def test_volume_mismatch(self) -> None:
+        """ρ≠1 → loss>0."""
+        pred = torch.tensor([[2.0, 4.0, 6.0, 8.0]])  # 2x target volume
+        target = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+        loss = mass_balance_loss(pred, target)
+        assert loss.item() > 0
+
+    def test_batch_dimension(self) -> None:
+        """Loss averages over multiple gauges."""
+        pred = torch.tensor([[1.0, 2.0], [3.0, 6.0]])  # G=2
+        target = torch.tensor([[1.0, 2.0], [3.0, 6.0]])
+        loss = mass_balance_loss(pred, target)
+        assert loss.item() < 1e-10
+
+    def test_gradient_is_finite(self) -> None:
+        pred = torch.tensor([[1.0, 2.0, 3.0]], requires_grad=True)
+        target = torch.tensor([[2.0, 3.0, 4.0]])
+        loss = mass_balance_loss(pred, target)
+        loss.backward()
+        assert pred.grad is not None
+        assert torch.isfinite(pred.grad).all()
+
+
+class TestKgeLoss:
+    """Test KGE loss."""
+
+    def test_perfect_prediction(self) -> None:
+        """Identical pred and target → loss ≈ eps (near zero)."""
+        pred = torch.tensor([[1.0, 2.0, 3.0, 4.0, 5.0]])
+        target = torch.tensor([[1.0, 2.0, 3.0, 4.0, 5.0]])
+        loss = kge_loss(pred, target)
+        assert loss.item() < 0.01
+
+    def test_poor_prediction(self) -> None:
+        """Uncorrelated series → loss > 0."""
+        pred = torch.tensor([[5.0, 4.0, 3.0, 2.0, 1.0]])
+        target = torch.tensor([[1.0, 2.0, 3.0, 4.0, 5.0]])
+        loss = kge_loss(pred, target)
+        assert loss.item() > 0.1
+
+    def test_gradient_is_finite(self) -> None:
+        pred = torch.tensor([[1.0, 2.0, 3.0, 4.0, 5.0]], requires_grad=True)
+        target = torch.tensor([[2.0, 3.0, 4.0, 5.0, 6.0]])
+        loss = kge_loss(pred, target)
+        loss.backward()
+        assert pred.grad is not None
+        assert torch.isfinite(pred.grad).all()
+
+    def test_constant_prediction_no_nan(self) -> None:
+        """Constant prediction (σ=0) should not produce NaN."""
+        pred = torch.tensor([[3.0, 3.0, 3.0, 3.0, 3.0]], requires_grad=True)
+        target = torch.tensor([[1.0, 2.0, 3.0, 4.0, 5.0]])
+        loss = kge_loss(pred, target)
+        assert torch.isfinite(loss)
+        loss.backward()
+        assert torch.isfinite(pred.grad).all()
+
+    def test_batch_dimension(self) -> None:
+        """Loss averages over multiple gauges."""
+        pred = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])  # G=2
+        target = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        loss = kge_loss(pred, target)
+        assert loss.item() < 0.01

--- a/tests/validation/test_losses.py
+++ b/tests/validation/test_losses.py
@@ -37,6 +37,17 @@ class TestMassBalanceLoss:
         assert pred.grad is not None
         assert torch.isfinite(pred.grad).all()
 
+    def test_gradient_does_not_flow_through_mc(self) -> None:
+        """mass_balance_loss on pre-MC q_corrected must not grad MC params."""
+        mc_layer = torch.nn.Linear(4, 4, bias=False)
+        q_corrected = torch.tensor([[1.0, 2.0, 3.0, 4.0]], requires_grad=True)
+        target = torch.tensor([[2.0, 3.0, 4.0, 5.0]])
+        _mc_output = mc_layer(q_corrected)  # MC processes but loss ignores
+        loss = mass_balance_loss(q_corrected, target)
+        loss.backward()
+        assert mc_layer.weight.grad is None, "MC should not receive gradients from mass_balance_loss"
+        assert q_corrected.grad is not None, "q_corrected should receive gradients"
+
 
 class TestKgeLoss:
     """Test KGE loss."""


### PR DESCRIPTION
## Summary

Foundation modules for KAN-based bias correction of lateral inflows (Phase 1 of #144). All new code — no existing functionality is modified. Bias correction is opt-in via `bias.enabled: true` in config.

- **`BiasCorrection` config + `PhiInputs` enum** — Pydantic model with 9 fields (phi_inputs mode, KAN hyperparameters, loss weights), wired into top-level `Config` with `default_factory` so existing configs are unaffected
- **`TemporalPhiKAN` module** — small KAN (`[input_dim, hidden, 1]`) that corrects Q' using flow magnitude + seasonal context (sin/cos month encoding). Supports 4 modes: static, monthly, forcing, random
- **`mass_balance_loss` + `kge_loss`** — differentiable loss functions for dual-loss training. Mass balance (ρ) gives φ direct gradients bypassing MC; KGE flows through MC for timing
- **Unit tests** — 30 new tests covering all modes, gradient flow, determinism, NaN safety, MC gradient isolation
- **Exports** — all new modules exported from `ddr.nn` and `ddr.validation`

### Files changed (9 files, +580 lines)

| File | Change |
|------|--------|
| `src/ddr/validation/enums.py` | `PhiInputs` StrEnum (static/monthly/forcing/random) |
| `src/ddr/validation/configs.py` | `BiasCorrection` model + `bias` field on `Config` |
| `src/ddr/nn/temporal_phi_kan.py` | **NEW** — `TemporalPhiKAN(nn.Module)` |
| `src/ddr/validation/losses.py` | **NEW** — `mass_balance_loss`, `kge_loss` |
| `src/ddr/nn/__init__.py` | Export `TemporalPhiKAN` |
| `src/ddr/validation/__init__.py` | Export `BiasCorrection`, `PhiInputs`, loss functions |
| `tests/validation/test_configs.py` | 8 tests for `BiasCorrection` |
| `tests/nn/test_temporal_phi_kan.py` | **NEW** — 11 tests for `TemporalPhiKAN` |
| `tests/validation/test_losses.py` | **NEW** — 10 tests for loss functions |

Closes #145, closes #146, closes #147, closes #148, closes #149

## Test plan

- [x] `pytest tests/nn/test_temporal_phi_kan.py -v` — all 11 tests pass
- [x] `pytest tests/validation/test_losses.py -v` — all 10 tests pass
- [x] `pytest tests/validation/test_configs.py -v` — all 22 tests pass (8 new + 14 existing)
- [x] `pytest tests/nn/ tests/validation/ -v` — all 69 tests pass, 0 regressions
- [x] Existing configs without `bias:` key validate correctly (default_factory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)