### PR TITLE
Temporal Phi KAN experiments with forcing readers and upgraded losses

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -13,6 +13,7 @@ from torch.utils.data import DataLoader, RandomSampler
 
 from ddr import ddr_functions, dmc, kan, streamflow
 from ddr._version import __version__
+from ddr.io.readers import ForcingsReader
 from ddr.nn import TemporalPhiKAN
 from ddr.scripts_utils import load_checkpoint, resolve_learning_rate
 from ddr.validation import Config, Metrics, plot_time_series, utils, validate_config
@@ -29,6 +30,7 @@ def train(
     nn: kan,
     phi_kan: TemporalPhiKAN | None = None,
     q_prime_stats: dict[str, dict[str, float]] | None = None,
+    forcings_reader: ForcingsReader | None = None,
 ) -> None:
     """Do model training."""
     data_generator = torch.Generator()
@@ -97,9 +99,15 @@ def train(
                         device=cfg.device,
                         dtype=torch.float32,
                     )
+                    forcing_tensor = None
+                    if forcings_reader is not None:
+                        forcing_tensor = forcings_reader(
+                            routing_dataclass=routing_dataclass, device=cfg.device, dtype=torch.float32
+                        )
                     streamflow_predictions = phi_kan(
                         streamflow_predictions,
                         month=month,
+                        forcing=forcing_tensor,
                         q_prime_mean=q_mean,
                         q_prime_std=q_std,
                     )
@@ -253,10 +261,15 @@ def main(cfg: DictConfig) -> None:
         routing_model = dmc(cfg=config, device=cfg.device)
         flow = streamflow(config)
 
+        forcings_reader = None
         if config.bias.enabled:
             from ddr.io.statistics import set_streamflow_statistics
+            from ddr.validation.enums import PhiInputs
 
             q_prime_stats = set_streamflow_statistics(config, flow.ds)
+            if config.bias.phi_inputs == PhiInputs.FORCING:
+                assert config.bias.forcing_var is not None
+                forcings_reader = ForcingsReader(config, forcing_var_names=[config.bias.forcing_var])
 
         train(
             cfg=config,
@@ -265,6 +278,7 @@ def main(cfg: DictConfig) -> None:
             nn=nn,
             phi_kan=phi_kan,
             q_prime_stats=q_prime_stats,
+            forcings_reader=forcings_reader,
         )
 
     except KeyboardInterrupt:

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -80,14 +80,17 @@ def train(
                 start_mini_batch = 0
                 routing_model.set_progress_info(epoch=epoch, mini_batch=i)
 
-                streamflow_predictions = flow(
-                    routing_dataclass=routing_dataclass, device=cfg.device, dtype=torch.float32
-                )
                 spatial_params = nn(inputs=routing_dataclass.normalized_spatial_attributes.to(cfg.device))
 
                 if phi_kan is not None:
                     assert q_prime_stats is not None
-                    month = dataset.dates.batch_month_tensor.to(cfg.device)
+                    # Get daily Q' for phi-KAN (24x less memory than hourly)
+                    q_prime_daily = flow(
+                        routing_dataclass=routing_dataclass,
+                        device=cfg.device,
+                        dtype=torch.float32,
+                        use_hourly=True,
+                    )
                     divide_ids = routing_dataclass.divide_ids
                     q_mean = torch.tensor(
                         [q_prime_stats.get(str(did), {}).get("mean", 1e-6) for did in divide_ids],
@@ -104,12 +107,21 @@ def train(
                         forcing_tensor = forcings_reader(
                             routing_dataclass=routing_dataclass, device=cfg.device, dtype=torch.float32
                         )
-                    streamflow_predictions = phi_kan(
-                        streamflow_predictions,
+                    # Bias-correct at daily resolution
+                    month = dataset.dates.batch_month_tensor_daily.to(cfg.device)
+                    q_prime_corrected = phi_kan(
+                        q_prime_daily,
                         month=month,
                         forcing=forcing_tensor,
                         q_prime_mean=q_mean,
                         q_prime_std=q_std,
+                    )
+                    # Interpolate corrected daily → hourly for MC routing
+                    T_hourly = len(routing_dataclass.dates.batch_hourly_time_range)
+                    streamflow_predictions = q_prime_corrected.repeat_interleave(24, dim=0)[:T_hourly]
+                else:
+                    streamflow_predictions = flow(
+                        routing_dataclass=routing_dataclass, device=cfg.device, dtype=torch.float32
                     )
 
                 dmc_kwargs = {

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -16,13 +16,19 @@ from ddr._version import __version__
 from ddr.nn import TemporalPhiKAN
 from ddr.scripts_utils import load_checkpoint, resolve_learning_rate
 from ddr.validation import Config, Metrics, plot_time_series, utils, validate_config
-from ddr.validation.losses import kge_loss, mass_balance_loss
+from ddr.validation.enums import BiasLossFn
+from ddr.validation.losses import huber_loss, kge_loss, mass_balance_loss
 
 log = logging.getLogger(__name__)
 
 
 def train(
-    cfg: Config, flow: streamflow, routing_model: dmc, nn: kan, phi_kan: TemporalPhiKAN | None = None
+    cfg: Config,
+    flow: streamflow,
+    routing_model: dmc,
+    nn: kan,
+    phi_kan: TemporalPhiKAN | None = None,
+    q_prime_stats: dict[str, dict[str, float]] | None = None,
 ) -> None:
     """Do model training."""
     data_generator = torch.Generator()
@@ -78,12 +84,24 @@ def train(
                 spatial_params = nn(inputs=routing_dataclass.normalized_spatial_attributes.to(cfg.device))
 
                 if phi_kan is not None:
+                    assert q_prime_stats is not None
                     month = dataset.dates.batch_month_tensor.to(cfg.device)
-                    grid_bounds = spatial_params.pop("grid_bounds", None)
+                    divide_ids = routing_dataclass.divide_ids
+                    q_mean = torch.tensor(
+                        [q_prime_stats.get(str(did), {}).get("mean", 1e-6) for did in divide_ids],
+                        device=cfg.device,
+                        dtype=torch.float32,
+                    )
+                    q_std = torch.tensor(
+                        [q_prime_stats.get(str(did), {}).get("std", 1e-8) for did in divide_ids],
+                        device=cfg.device,
+                        dtype=torch.float32,
+                    )
                     streamflow_predictions = phi_kan(
                         streamflow_predictions,
                         month=month,
-                        grid_bounds=grid_bounds,
+                        q_prime_mean=q_mean,
+                        q_prime_std=q_std,
                     )
 
                 dmc_kwargs = {
@@ -109,16 +127,21 @@ def train(
 
                 filtered_predictions = daily_runoff[~np_nan_mask]
 
-                if phi_kan is not None and cfg.bias.use_kge_loss:
+                if phi_kan is not None:
                     pred_gt = filtered_predictions.transpose(0, 1)[cfg.experiment.warmup :]
                     obs_gt = filtered_observations.transpose(0, 1)[cfg.experiment.warmup :]
                     mb_loss = mass_balance_loss(pred_gt, obs_gt)
-                    kge = kge_loss(pred_gt, obs_gt)
-                    loss = cfg.bias.lambda_mass * mb_loss + (1 - cfg.bias.lambda_mass) * kge
+                    if cfg.bias.loss_fn == BiasLossFn.HUBER:
+                        routing_loss = huber_loss(pred_gt, obs_gt)
+                    elif cfg.bias.loss_fn == BiasLossFn.KGE:
+                        routing_loss = kge_loss(pred_gt, obs_gt)
+                    else:
+                        routing_loss = mse_loss(pred_gt, obs_gt)
+                    loss = cfg.bias.lambda_mass * mb_loss + (1 - cfg.bias.lambda_mass) * routing_loss
                 else:
-                    loss = mse_loss(
-                        input=filtered_predictions.transpose(0, 1)[cfg.experiment.warmup :].unsqueeze(2),
-                        target=filtered_observations.transpose(0, 1)[cfg.experiment.warmup :].unsqueeze(2),
+                    loss = huber_loss(
+                        filtered_predictions.transpose(0, 1)[cfg.experiment.warmup :],
+                        filtered_observations.transpose(0, 1)[cfg.experiment.warmup :],
                     )
 
                 log.info("Running backpropagation")
@@ -138,9 +161,10 @@ def train(
                 rmse = metrics.rmse
                 kge_metric = metrics.kge
                 utils.log_metrics(nse, rmse, kge_metric, epoch=epoch, mini_batch=i)
-                if phi_kan is not None and cfg.bias.use_kge_loss:
+                if phi_kan is not None:
                     log.info(
-                        f"Loss: {loss.item():.6f} (mass_balance: {mb_loss.item():.6f}, kge: {kge.item():.6f})"
+                        f"Loss: {loss.item():.6f} (mass_balance: {mb_loss.item():.6f}, "
+                        f"{cfg.bias.loss_fn.value}: {routing_loss.item():.6f})"
                     )
                 else:
                     log.info(f"Loss: {loss.item()}")
@@ -185,6 +209,14 @@ def train(
                     phi_kan=phi_kan,
                 )
 
+                # Free autograd graph from this mini-batch so the next
+                # iteration doesn't OOM during the phi_kan forward pass.
+                del dmc_output, daily_runoff, streamflow_predictions, loss
+                del filtered_predictions, filtered_observations
+                routing_model.routing_engine.q_prime = None
+                routing_model.routing_engine._discharge_t = None
+                torch.cuda.empty_cache()
+
 
 @hydra.main(
     version_base="1.3",
@@ -207,11 +239,10 @@ def main(cfg: DictConfig) -> None:
             k=config.kan.k,
             seed=config.seed,
             device=config.device,
-            output_grid_bounds=config.bias.enabled,
-            bias_cfg=config.bias if config.bias.enabled else None,
         )
 
         phi_kan = None
+        q_prime_stats = None
         if config.bias.enabled:
             phi_kan = TemporalPhiKAN(
                 cfg=config.bias,
@@ -221,7 +252,20 @@ def main(cfg: DictConfig) -> None:
 
         routing_model = dmc(cfg=config, device=cfg.device)
         flow = streamflow(config)
-        train(cfg=config, flow=flow, routing_model=routing_model, nn=nn, phi_kan=phi_kan)
+
+        if config.bias.enabled:
+            from ddr.io.statistics import set_streamflow_statistics
+
+            q_prime_stats = set_streamflow_statistics(config, flow.ds)
+
+        train(
+            cfg=config,
+            flow=flow,
+            routing_model=routing_model,
+            nn=nn,
+            phi_kan=phi_kan,
+            q_prime_stats=q_prime_stats,
+        )
 
     except KeyboardInterrupt:
         log.info("Keyboard interrupt received")

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -13,20 +13,24 @@ from torch.utils.data import DataLoader, RandomSampler
 
 from ddr import ddr_functions, dmc, kan, streamflow
 from ddr._version import __version__
+from ddr.nn import TemporalPhiKAN
 from ddr.scripts_utils import load_checkpoint, resolve_learning_rate
 from ddr.validation import Config, Metrics, plot_time_series, utils, validate_config
+from ddr.validation.losses import kge_loss, mass_balance_loss
 
 log = logging.getLogger(__name__)
 
 
-def train(cfg: Config, flow: streamflow, routing_model: dmc, nn: kan) -> None:
+def train(
+    cfg: Config, flow: streamflow, routing_model: dmc, nn: kan, phi_kan: TemporalPhiKAN | None = None
+) -> None:
     """Do model training."""
     data_generator = torch.Generator()
     data_generator.manual_seed(cfg.seed)
     dataset = cfg.geodataset.get_dataset_class(cfg=cfg)
 
     if cfg.experiment.checkpoint:
-        state = load_checkpoint(nn, cfg.experiment.checkpoint, torch.device(cfg.device))
+        state = load_checkpoint(nn, cfg.experiment.checkpoint, torch.device(cfg.device), phi_kan=phi_kan)
         start_epoch = state["epoch"]
         start_mini_batch = (
             0 if state["mini_batch"] == 0 else state["mini_batch"] + 1
@@ -38,7 +42,10 @@ def train(cfg: Config, flow: streamflow, routing_model: dmc, nn: kan) -> None:
         start_mini_batch = 0
         lr = cfg.experiment.learning_rate[start_epoch]
 
-    optimizer = torch.optim.Adam(params=nn.parameters(), lr=lr)
+    params_to_optimize = list(nn.parameters())
+    if phi_kan is not None:
+        params_to_optimize += list(phi_kan.parameters())
+    optimizer = torch.optim.Adam(params=params_to_optimize, lr=lr)
     sampler = RandomSampler(
         data_source=dataset,
         generator=data_generator,
@@ -69,6 +76,16 @@ def train(cfg: Config, flow: streamflow, routing_model: dmc, nn: kan) -> None:
                     routing_dataclass=routing_dataclass, device=cfg.device, dtype=torch.float32
                 )
                 spatial_params = nn(inputs=routing_dataclass.normalized_spatial_attributes.to(cfg.device))
+
+                if phi_kan is not None:
+                    month = dataset.dates.batch_month_tensor.to(cfg.device)
+                    grid_bounds = spatial_params.pop("grid_bounds", None)
+                    streamflow_predictions = phi_kan(
+                        streamflow_predictions,
+                        month=month,
+                        grid_bounds=grid_bounds,
+                    )
+
                 dmc_kwargs = {
                     "routing_dataclass": routing_dataclass,
                     "spatial_parameters": spatial_params,
@@ -92,15 +109,22 @@ def train(cfg: Config, flow: streamflow, routing_model: dmc, nn: kan) -> None:
 
                 filtered_predictions = daily_runoff[~np_nan_mask]
 
-                loss = mse_loss(
-                    input=filtered_predictions.transpose(0, 1)[cfg.experiment.warmup :].unsqueeze(2),
-                    target=filtered_observations.transpose(0, 1)[cfg.experiment.warmup :].unsqueeze(2),
-                )
+                if phi_kan is not None and cfg.bias.use_kge_loss:
+                    pred_gt = filtered_predictions.transpose(0, 1)[cfg.experiment.warmup :]
+                    obs_gt = filtered_observations.transpose(0, 1)[cfg.experiment.warmup :]
+                    mb_loss = mass_balance_loss(pred_gt, obs_gt)
+                    kge = kge_loss(pred_gt, obs_gt)
+                    loss = cfg.bias.lambda_mass * mb_loss + (1 - cfg.bias.lambda_mass) * kge
+                else:
+                    loss = mse_loss(
+                        input=filtered_predictions.transpose(0, 1)[cfg.experiment.warmup :].unsqueeze(2),
+                        target=filtered_observations.transpose(0, 1)[cfg.experiment.warmup :].unsqueeze(2),
+                    )
 
                 log.info("Running backpropagation")
 
                 loss.backward()
-                torch.nn.utils.clip_grad_norm_(nn.parameters(), max_norm=1.0)
+                torch.nn.utils.clip_grad_norm_(params_to_optimize, max_norm=1.0)
                 optimizer.step()
                 optimizer.zero_grad()
 
@@ -112,9 +136,14 @@ def train(cfg: Config, flow: streamflow, routing_model: dmc, nn: kan) -> None:
                 _nse = metrics.nse
                 nse = _nse[~np.isinf(_nse) & ~np.isnan(_nse)]
                 rmse = metrics.rmse
-                kge = metrics.kge
-                utils.log_metrics(nse, rmse, kge, epoch=epoch, mini_batch=i)
-                log.info(f"Loss: {loss.item()}")
+                kge_metric = metrics.kge
+                utils.log_metrics(nse, rmse, kge_metric, epoch=epoch, mini_batch=i)
+                if phi_kan is not None and cfg.bias.use_kge_loss:
+                    log.info(
+                        f"Loss: {loss.item():.6f} (mass_balance: {mb_loss.item():.6f}, kge: {kge.item():.6f})"
+                    )
+                else:
+                    log.info(f"Loss: {loss.item()}")
 
                 # Log parameter ranges for all learnable routing parameters
                 param_map = {
@@ -153,6 +182,7 @@ def train(cfg: Config, flow: streamflow, routing_model: dmc, nn: kan) -> None:
                     optimizer=optimizer,
                     name=cfg.name,
                     saved_model_path=cfg.params.save_path / "saved_models",
+                    phi_kan=phi_kan,
                 )
 
 
@@ -177,10 +207,21 @@ def main(cfg: DictConfig) -> None:
             k=config.kan.k,
             seed=config.seed,
             device=config.device,
+            output_grid_bounds=config.bias.enabled,
+            bias_cfg=config.bias if config.bias.enabled else None,
         )
+
+        phi_kan = None
+        if config.bias.enabled:
+            phi_kan = TemporalPhiKAN(
+                cfg=config.bias,
+                seed=config.seed,
+                device=config.device,
+            )
+
         routing_model = dmc(cfg=config, device=cfg.device)
         flow = streamflow(config)
-        train(cfg=config, flow=flow, routing_model=routing_model, nn=nn)
+        train(cfg=config, flow=flow, routing_model=routing_model, nn=nn, phi_kan=phi_kan)
 
     except KeyboardInterrupt:
         log.info("Keyboard interrupt received")

--- a/scripts/train_and_test.py
+++ b/scripts/train_and_test.py
@@ -81,14 +81,17 @@ def _test(
         for i, routing_dataclass in enumerate(dataloader, start=0):
             routing_model.set_progress_info(epoch=0, mini_batch=i)
 
-            streamflow_predictions = flow(
-                routing_dataclass=routing_dataclass, device=cfg.device, dtype=torch.float32
-            )
             spatial_params = nn(inputs=routing_dataclass.normalized_spatial_attributes.to(cfg.device))
 
             if phi_kan is not None:
                 assert q_prime_stats is not None
-                month = dataset.dates.batch_month_tensor.to(cfg.device)
+                # Get daily Q' for phi-KAN (24x less memory than hourly)
+                q_prime_daily = flow(
+                    routing_dataclass=routing_dataclass,
+                    device=cfg.device,
+                    dtype=torch.float32,
+                    use_hourly=True,
+                )
                 divide_ids = routing_dataclass.divide_ids
                 q_mean = torch.tensor(
                     [q_prime_stats.get(str(did), {}).get("mean", 1e-6) for did in divide_ids],
@@ -105,12 +108,21 @@ def _test(
                     forcing_tensor = forcings_reader(
                         routing_dataclass=routing_dataclass, device=cfg.device, dtype=torch.float32
                     )
-                streamflow_predictions = phi_kan(
-                    streamflow_predictions,
+                # Bias-correct at daily resolution
+                month = dataset.dates.batch_month_tensor_daily.to(cfg.device)
+                q_prime_corrected = phi_kan(
+                    q_prime_daily,
                     month=month,
                     forcing=forcing_tensor,
                     q_prime_mean=q_mean,
                     q_prime_std=q_std,
+                )
+                # Interpolate corrected daily → hourly for MC routing
+                T_hourly = len(routing_dataclass.dates.batch_hourly_time_range)
+                streamflow_predictions = q_prime_corrected.repeat_interleave(24, dim=0)[:T_hourly]
+            else:
+                streamflow_predictions = flow(
+                    routing_dataclass=routing_dataclass, device=cfg.device, dtype=torch.float32
                 )
 
             dmc_kwargs = {

--- a/scripts/train_and_test.py
+++ b/scripts/train_and_test.py
@@ -25,6 +25,7 @@ from torch.utils.data import DataLoader, SequentialSampler
 
 from ddr import dmc, kan, streamflow
 from ddr._version import __version__
+from ddr.io.readers import ForcingsReader
 from ddr.nn import TemporalPhiKAN
 from ddr.scripts_utils import compute_daily_runoff, load_checkpoint
 from ddr.validation import Config, Metrics, utils, validate_config
@@ -40,6 +41,7 @@ def _test(
     nn: kan,
     phi_kan: TemporalPhiKAN | None = None,
     q_prime_stats: dict[str, dict[str, float]] | None = None,
+    forcings_reader: ForcingsReader | None = None,
 ) -> None:
     """Do model evaluation and get performance metrics."""
     dataset = cfg.geodataset.get_dataset_class(cfg=cfg)
@@ -98,9 +100,15 @@ def _test(
                     device=cfg.device,
                     dtype=torch.float32,
                 )
+                forcing_tensor = None
+                if forcings_reader is not None:
+                    forcing_tensor = forcings_reader(
+                        routing_dataclass=routing_dataclass, device=cfg.device, dtype=torch.float32
+                    )
                 streamflow_predictions = phi_kan(
                     streamflow_predictions,
                     month=month,
+                    forcing=forcing_tensor,
                     q_prime_mean=q_mean,
                     q_prime_std=q_std,
                 )
@@ -199,10 +207,15 @@ def main(cfg: DictConfig) -> None:
         routing_model = dmc(cfg=config, device=cfg.device)
         flow = streamflow(config)
 
+        forcings_reader = None
         if config.bias.enabled:
             from ddr.io.statistics import set_streamflow_statistics
+            from ddr.validation.enums import PhiInputs
 
             q_prime_stats = set_streamflow_statistics(config, flow.ds)
+            if config.bias.phi_inputs == PhiInputs.FORCING:
+                assert config.bias.forcing_var is not None
+                forcings_reader = ForcingsReader(config, forcing_var_names=[config.bias.forcing_var])
 
         train(
             cfg=config,
@@ -211,6 +224,7 @@ def main(cfg: DictConfig) -> None:
             nn=nn_model,
             phi_kan=phi_kan,
             q_prime_stats=q_prime_stats,
+            forcings_reader=forcings_reader,
         )
 
         train_elapsed = time.perf_counter() - start_time
@@ -265,6 +279,7 @@ def main(cfg: DictConfig) -> None:
             nn=nn_model,
             phi_kan=phi_kan,
             q_prime_stats=q_prime_stats,
+            forcings_reader=forcings_reader,
         )
 
     except KeyboardInterrupt:

--- a/scripts/train_and_test.py
+++ b/scripts/train_and_test.py
@@ -39,6 +39,7 @@ def _test(
     routing_model: dmc,
     nn: kan,
     phi_kan: TemporalPhiKAN | None = None,
+    q_prime_stats: dict[str, dict[str, float]] | None = None,
 ) -> None:
     """Do model evaluation and get performance metrics."""
     dataset = cfg.geodataset.get_dataset_class(cfg=cfg)
@@ -84,12 +85,24 @@ def _test(
             spatial_params = nn(inputs=routing_dataclass.normalized_spatial_attributes.to(cfg.device))
 
             if phi_kan is not None:
+                assert q_prime_stats is not None
                 month = dataset.dates.batch_month_tensor.to(cfg.device)
-                grid_bounds = spatial_params.pop("grid_bounds", None)
+                divide_ids = routing_dataclass.divide_ids
+                q_mean = torch.tensor(
+                    [q_prime_stats.get(str(did), {}).get("mean", 1e-6) for did in divide_ids],
+                    device=cfg.device,
+                    dtype=torch.float32,
+                )
+                q_std = torch.tensor(
+                    [q_prime_stats.get(str(did), {}).get("std", 1e-8) for did in divide_ids],
+                    device=cfg.device,
+                    dtype=torch.float32,
+                )
                 streamflow_predictions = phi_kan(
                     streamflow_predictions,
                     month=month,
-                    grid_bounds=grid_bounds,
+                    q_prime_mean=q_mean,
+                    q_prime_std=q_std,
                 )
 
             dmc_kwargs = {
@@ -172,11 +185,10 @@ def main(cfg: DictConfig) -> None:
             k=config.kan.k,
             seed=config.seed,
             device=config.device,
-            output_grid_bounds=config.bias.enabled,
-            bias_cfg=config.bias if config.bias.enabled else None,
         )
 
         phi_kan = None
+        q_prime_stats = None
         if config.bias.enabled:
             phi_kan = TemporalPhiKAN(
                 cfg=config.bias,
@@ -187,7 +199,19 @@ def main(cfg: DictConfig) -> None:
         routing_model = dmc(cfg=config, device=cfg.device)
         flow = streamflow(config)
 
-        train(cfg=config, flow=flow, routing_model=routing_model, nn=nn_model, phi_kan=phi_kan)
+        if config.bias.enabled:
+            from ddr.io.statistics import set_streamflow_statistics
+
+            q_prime_stats = set_streamflow_statistics(config, flow.ds)
+
+        train(
+            cfg=config,
+            flow=flow,
+            routing_model=routing_model,
+            nn=nn_model,
+            phi_kan=phi_kan,
+            q_prime_stats=q_prime_stats,
+        )
 
         train_elapsed = time.perf_counter() - start_time
         log.info(f"Training complete in {train_elapsed / 60:.2f} minutes")
@@ -221,8 +245,6 @@ def main(cfg: DictConfig) -> None:
             k=test_config.kan.k,
             seed=test_config.seed,
             device=test_config.device,
-            output_grid_bounds=test_config.bias.enabled,
-            bias_cfg=test_config.bias if test_config.bias.enabled else None,
         )
 
         phi_kan = None
@@ -236,7 +258,14 @@ def main(cfg: DictConfig) -> None:
         routing_model = dmc(cfg=test_config, device=test_config.device)
         flow = streamflow(test_config)
 
-        _test(cfg=test_config, flow=flow, routing_model=routing_model, nn=nn_model, phi_kan=phi_kan)
+        _test(
+            cfg=test_config,
+            flow=flow,
+            routing_model=routing_model,
+            nn=nn_model,
+            phi_kan=phi_kan,
+            q_prime_stats=q_prime_stats,
+        )
 
     except KeyboardInterrupt:
         log.info("Keyboard interrupt received")

--- a/scripts/train_and_test.py
+++ b/scripts/train_and_test.py
@@ -25,6 +25,7 @@ from torch.utils.data import DataLoader, SequentialSampler
 
 from ddr import dmc, kan, streamflow
 from ddr._version import __version__
+from ddr.nn import TemporalPhiKAN
 from ddr.scripts_utils import compute_daily_runoff, load_checkpoint
 from ddr.validation import Config, Metrics, utils, validate_config
 from scripts.train import train
@@ -37,16 +38,19 @@ def _test(
     flow: streamflow,
     routing_model: dmc,
     nn: kan,
+    phi_kan: TemporalPhiKAN | None = None,
 ) -> None:
     """Do model evaluation and get performance metrics."""
     dataset = cfg.geodataset.get_dataset_class(cfg=cfg)
 
     if cfg.experiment.checkpoint:
-        load_checkpoint(nn, cfg.experiment.checkpoint, torch.device(cfg.device))
+        load_checkpoint(nn, cfg.experiment.checkpoint, torch.device(cfg.device), phi_kan=phi_kan)
     else:
         log.warning("Creating new spatial model for evaluation.")
 
     nn = nn.eval()
+    if phi_kan is not None:
+        phi_kan = phi_kan.eval()
     sampler = SequentialSampler(
         data_source=dataset,
     )
@@ -78,6 +82,16 @@ def _test(
                 routing_dataclass=routing_dataclass, device=cfg.device, dtype=torch.float32
             )
             spatial_params = nn(inputs=routing_dataclass.normalized_spatial_attributes.to(cfg.device))
+
+            if phi_kan is not None:
+                month = dataset.dates.batch_month_tensor.to(cfg.device)
+                grid_bounds = spatial_params.pop("grid_bounds", None)
+                streamflow_predictions = phi_kan(
+                    streamflow_predictions,
+                    month=month,
+                    grid_bounds=grid_bounds,
+                )
+
             dmc_kwargs = {
                 "routing_dataclass": routing_dataclass,
                 "spatial_parameters": spatial_params,
@@ -158,11 +172,22 @@ def main(cfg: DictConfig) -> None:
             k=config.kan.k,
             seed=config.seed,
             device=config.device,
+            output_grid_bounds=config.bias.enabled,
+            bias_cfg=config.bias if config.bias.enabled else None,
         )
+
+        phi_kan = None
+        if config.bias.enabled:
+            phi_kan = TemporalPhiKAN(
+                cfg=config.bias,
+                seed=config.seed,
+                device=config.device,
+            )
+
         routing_model = dmc(cfg=config, device=cfg.device)
         flow = streamflow(config)
 
-        train(cfg=config, flow=flow, routing_model=routing_model, nn=nn_model)
+        train(cfg=config, flow=flow, routing_model=routing_model, nn=nn_model, phi_kan=phi_kan)
 
         train_elapsed = time.perf_counter() - start_time
         log.info(f"Training complete in {train_elapsed / 60:.2f} minutes")
@@ -196,11 +221,22 @@ def main(cfg: DictConfig) -> None:
             k=test_config.kan.k,
             seed=test_config.seed,
             device=test_config.device,
+            output_grid_bounds=test_config.bias.enabled,
+            bias_cfg=test_config.bias if test_config.bias.enabled else None,
         )
+
+        phi_kan = None
+        if test_config.bias.enabled:
+            phi_kan = TemporalPhiKAN(
+                cfg=test_config.bias,
+                seed=test_config.seed,
+                device=test_config.device,
+            )
+
         routing_model = dmc(cfg=test_config, device=test_config.device)
         flow = streamflow(test_config)
 
-        _test(cfg=test_config, flow=flow, routing_model=routing_model, nn=nn_model)
+        _test(cfg=test_config, flow=flow, routing_model=routing_model, nn=nn_model, phi_kan=phi_kan)
 
     except KeyboardInterrupt:
         log.info("Keyboard interrupt received")

--- a/src/ddr/geodatazoo/dataclasses.py
+++ b/src/ddr/geodatazoo/dataclasses.py
@@ -195,6 +195,11 @@ class Dates(BaseModel):
         """Month values [1-12] for each hourly timestep in current batch."""
         return torch.tensor(self.batch_hourly_time_range.month.values, dtype=torch.float32)
 
+    @property
+    def batch_month_tensor_daily(self) -> torch.Tensor:
+        """Month values [1-12] for each daily timestep in current batch."""
+        return torch.tensor(self.batch_daily_time_range.month.values, dtype=torch.float32)
+
     def create_time_windows(self) -> np.ndarray:
         """Creates the time slices, or windows, for testing the model"""
         if self.rho is None:

--- a/src/ddr/geodatazoo/dataclasses.py
+++ b/src/ddr/geodatazoo/dataclasses.py
@@ -76,6 +76,7 @@ class Dates(BaseModel):
     start_time: str
     end_time: str
     rho: int | None = None
+    seed: int = 42
     batch_daily_time_range: pd.DatetimeIndex = pd.DatetimeIndex([], dtype="datetime64[ns]")
     batch_hourly_time_range: pd.DatetimeIndex = pd.DatetimeIndex([], dtype="datetime64[ns]")
     daily_time_range: pd.DatetimeIndex = pd.DatetimeIndex([], dtype="datetime64[ns]")
@@ -83,13 +84,18 @@ class Dates(BaseModel):
     hourly_time_range: pd.DatetimeIndex = pd.DatetimeIndex([], dtype="datetime64[ns]")
     hourly_indices: torch.Tensor = torch.empty(0)
     numerical_time_range: np.ndarray = np.empty(0)
+    _rng: torch.Generator | None = None
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(
             start_time=kwargs["start_time"],
             end_time=kwargs["end_time"],
             rho=kwargs.get("rho"),
+            seed=kwargs.get("seed", 42),
         )
+        # Dedicated RNG for time window sampling — isolated from model operations
+        self._rng = torch.Generator()
+        self._rng.manual_seed(self.seed)
 
     @model_validator(mode="after")
     @classmethod
@@ -158,10 +164,17 @@ class Dates(BaseModel):
         self.daily_indices = np.array([self.daily_time_range.get_loc(time) for time in common_elements])
 
     def calculate_time_period(self) -> None:
-        """Calculates the time period for the dataset using rho"""
+        """Calculates the time period for the dataset using rho.
+
+        Uses a dedicated RNG (seeded at init) so that the sequence of time
+        windows is identical across experiments regardless of model operations
+        that advance the global torch RNG.
+        """
         if self.rho is not None:
             sample_size = len(self.daily_time_range)
-            random_start_tensor = torch.randint(low=0, high=sample_size - self.rho, size=(1, 1))
+            random_start_tensor = torch.randint(
+                low=0, high=sample_size - self.rho, size=(1, 1), generator=self._rng
+            )
             random_start = int(random_start_tensor[0][0].item())
             self.batch_daily_time_range = self.daily_time_range[random_start : (random_start + self.rho)]
             self.set_batch_time(self.batch_daily_time_range)

--- a/src/ddr/geodatazoo/dataclasses.py
+++ b/src/ddr/geodatazoo/dataclasses.py
@@ -177,6 +177,11 @@ class Dates(BaseModel):
         self.batch_daily_time_range = self.daily_time_range[chunk]
         self.set_batch_time(self.batch_daily_time_range)
 
+    @property
+    def batch_month_tensor(self) -> torch.Tensor:
+        """Month values [1-12] for each hourly timestep in current batch."""
+        return torch.tensor(self.batch_hourly_time_range.month.values, dtype=torch.float32)
+
     def create_time_windows(self) -> np.ndarray:
         """Creates the time slices, or windows, for testing the model"""
         if self.rho is None:

--- a/src/ddr/geodatazoo/lynker_hydrofabric.py
+++ b/src/ddr/geodatazoo/lynker_hydrofabric.py
@@ -39,7 +39,7 @@ class LynkerHydrofabric(BaseGeoDataset):
 
     def __init__(self, cfg: Config) -> None:
         self.cfg = cfg
-        self.dates = Dates(**self.cfg.experiment.model_dump())
+        self.dates = Dates(**self.cfg.experiment.model_dump(), seed=self.cfg.seed)
         self.gage_ids: np.ndarray | None = None
         self.routing_dataclass: RoutingDataclass | None = None
         self.network_graph: rx.PyDiGraph | None = None

--- a/src/ddr/geodatazoo/merit.py
+++ b/src/ddr/geodatazoo/merit.py
@@ -40,7 +40,7 @@ class Merit(BaseGeoDataset):
 
     def __init__(self, cfg: "Config") -> None:
         self.cfg = cfg
-        self.dates = Dates(**self.cfg.experiment.model_dump())
+        self.dates = Dates(**self.cfg.experiment.model_dump(), seed=self.cfg.seed)
         self.gage_ids: np.ndarray | None = None
         self.routing_dataclass: RoutingDataclass | None = None
         self.network_graph: rx.PyDiGraph | None = None

--- a/src/ddr/io/readers.py
+++ b/src/ddr/io/readers.py
@@ -1,6 +1,7 @@
 """A file to handle all reading from data sources"""
 
 import logging
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -533,6 +534,100 @@ class IcechunkUSGSReader:
         padded_gage_ids = [str(gage_id).zfill(8) for gage_id in self.gage_dict["STAID"]]
         ds_ = self.ds.sel(gage_id=padded_gage_ids).isel(time=dates.numerical_time_range)
         return ds_
+
+
+class ForcingsReader(torch.nn.Module):
+    """A class to read meteorological forcings (P, PET, Temp) from an icechunk store."""
+
+    def __init__(self, cfg: Config, forcing_var_names: list[str]) -> None:
+        super().__init__()
+        self.cfg = cfg
+        assert cfg.data_sources.forcings is not None, "data_sources.forcings must be set"
+        self.ds = read_ic(cfg.data_sources.forcings, region=cfg.s3_region)
+        self.forcing_var_names = forcing_var_names
+        # Index Lookup Dictionary
+        self.divide_id_to_index = {divide_id: idx for idx, divide_id in enumerate(self.ds.divide_id.values)}
+        # Compute time offset: forcings store may not start at 1980-01-01 (the Dates origin)
+        first_time = pd.Timestamp(self.ds.time.values[0])
+        origin = pd.Timestamp("1980-01-01")
+        self._time_offset = (first_time - origin).days
+
+        # Load or compute forcing statistics for z-score normalization
+        from ddr.io.statistics import set_forcing_statistics
+
+        forcing_stats = set_forcing_statistics(cfg, self.ds, forcing_var_names)
+        self.forcing_means = torch.tensor(
+            [forcing_stats[var]["mean"] for var in self.forcing_var_names],
+            dtype=torch.float32,
+        )
+        self.forcing_stds = torch.tensor(
+            [forcing_stats[var]["std"] for var in self.forcing_var_names],
+            dtype=torch.float32,
+        )
+
+    def forward(self, **kwargs: Any) -> torch.Tensor:
+        """Read forcing variables for the given routing dataclass.
+
+        Returns
+        -------
+        torch.Tensor
+            Forcing data with shape (T_daily, N, num_forcing_vars), dtype float32.
+            When num_forcing_vars == 1, squeeze to (T_daily, N).
+        """
+        routing_dataclass = kwargs["routing_dataclass"]
+        device = kwargs.get("device", "cpu")
+        dtype = kwargs.get("dtype", torch.float32)
+
+        valid_divide_indices = []
+        divide_idx_mask: list[int] = []
+        missing_count = 0
+
+        for i, divide_id in enumerate(routing_dataclass.divide_ids):
+            if divide_id in self.divide_id_to_index:
+                valid_divide_indices.append(self.divide_id_to_index[divide_id])
+                divide_idx_mask.append(i)
+            else:
+                missing_count += 1
+
+        if missing_count > 0:
+            total = len(routing_dataclass.divide_ids)
+            log.info(f"{missing_count}/{total} divide IDs missing from forcings (zero-filled)")
+
+        assert len(valid_divide_indices) != 0, "No valid divide IDs found in forcings store"
+
+        # Convert Dates numerical_time_range (days from 1980-01-01) to forcings store indices
+        forcings_indices = routing_dataclass.dates.numerical_time_range - self._time_offset
+
+        N = len(routing_dataclass.divide_ids)
+        T = len(forcings_indices)
+        num_vars = len(self.forcing_var_names)
+
+        # Read each forcing variable and stack
+        var_tensors = []
+        for var_name in self.forcing_var_names:
+            _ds = self.ds[var_name].isel(time=forcings_indices, divide_id=valid_divide_indices)
+            data = _ds.compute().values.astype(np.float32).T  # (T, num_valid)
+            # Fill NaN with per-basin temporal mean; if entire basin is NaN, fall back to 0.0
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=RuntimeWarning)
+                basin_means = np.nanmean(data, axis=0, keepdims=True)  # (1, num_valid)
+            nan_mask = np.isnan(data)
+            data = np.where(nan_mask, basin_means, data)
+            data = np.nan_to_num(data, nan=0.0)
+            var_tensor = torch.full((T, N), 0.0, dtype=dtype)
+            var_tensor[:, divide_idx_mask] = torch.tensor(data, dtype=dtype)
+            var_tensors.append(var_tensor)
+
+        # Stack: [T, N, num_vars]
+        output = torch.stack(var_tensors, dim=-1).to(device)
+        assert output.shape == (T, N, num_vars)
+        # Z-score normalize: (x - mean) / std
+        output = (output - self.forcing_means.to(device)) / self.forcing_stds.to(device)
+
+        # For single forcing variable (phi-KAN FORCING mode), squeeze to (T, N)
+        if num_vars == 1:
+            return output.squeeze(-1)
+        return output
 
 
 class AttributesReader(torch.nn.Module):

--- a/src/ddr/io/readers.py
+++ b/src/ddr/io/readers.py
@@ -599,14 +599,13 @@ class ForcingsReader(torch.nn.Module):
         forcings_indices = routing_dataclass.dates.numerical_time_range - self._time_offset
 
         N = len(routing_dataclass.divide_ids)
-        T = len(forcings_indices)
         num_vars = len(self.forcing_var_names)
 
-        # Read each forcing variable and stack
+        # Read each forcing variable and stack (daily resolution)
         var_tensors = []
         for var_name in self.forcing_var_names:
             _ds = self.ds[var_name].isel(time=forcings_indices, divide_id=valid_divide_indices)
-            data = _ds.compute().values.astype(np.float32).T  # (T, num_valid)
+            data = _ds.compute().values.astype(np.float32).T  # (T_daily, num_valid)
             # Fill NaN with per-basin temporal mean; if entire basin is NaN, fall back to 0.0
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=RuntimeWarning)
@@ -614,13 +613,13 @@ class ForcingsReader(torch.nn.Module):
             nan_mask = np.isnan(data)
             data = np.where(nan_mask, basin_means, data)
             data = np.nan_to_num(data, nan=0.0)
-            var_tensor = torch.full((T, N), 0.0, dtype=dtype)
+            T_daily = data.shape[0]
+            var_tensor = torch.full((T_daily, N), 0.0, dtype=dtype)
             var_tensor[:, divide_idx_mask] = torch.tensor(data, dtype=dtype)
             var_tensors.append(var_tensor)
 
-        # Stack: [T, N, num_vars]
+        # Stack: [T_out, N, num_vars]
         output = torch.stack(var_tensors, dim=-1).to(device)
-        assert output.shape == (T, N, num_vars)
         # Z-score normalize: (x - mean) / std
         output = (output - self.forcing_means.to(device)) / self.forcing_stds.to(device)
 

--- a/src/ddr/io/statistics.py
+++ b/src/ddr/io/statistics.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import xarray as xr
+from tqdm import tqdm
 
 from ddr.validation.configs import Config
 
@@ -95,7 +96,8 @@ def set_streamflow_statistics(cfg: Config, ds: xr.Dataset) -> dict[str, dict[str
     chunk_size = 1000
     result: dict[str, dict[str, float]] = {}
 
-    for start in range(0, num_divides, chunk_size):
+    chunks = range(0, num_divides, chunk_size)
+    for start in tqdm(chunks, total=len(chunks), desc="Computing Q' statistics", ncols=140, ascii=True):
         end = min(start + chunk_size, num_divides)
         chunk = ds["Qr"].isel(divide_id=slice(start, end)).values  # (time, chunk_size)
         chunk_ids = divide_ids[start:end]
@@ -108,10 +110,59 @@ def set_streamflow_statistics(cfg: Config, ds: xr.Dataset) -> dict[str, dict[str
             std_val = float(stds[i]) if not np.isnan(stds[i]) and stds[i] > 0 else 1e-8
             result[str(did)] = {"mean": mean_val, "std": std_val}
 
-        log.info(f"  Processed {end}/{num_divides} divide_ids")
-
     with open(stats_file, "w") as f:
         json.dump(result, f)
     log.info(f"Saved streamflow statistics to {stats_file.name}")
+
+    return result
+
+
+def set_forcing_statistics(
+    cfg: Config, ds: xr.Dataset, forcing_var_names: list[str]
+) -> dict[str, dict[str, float]]:
+    """Compute or load normalization statistics for forcing variables.
+
+    Parameters
+    ----------
+    cfg : Config
+        The configuration object.
+    ds : xr.Dataset
+        The forcings xarray dataset (dims: divide_id x time).
+    forcing_var_names : list[str]
+        Names of forcing variables to compute statistics for.
+
+    Returns
+    -------
+    dict[str, dict[str, float]]
+        Mapping of variable name -> {"min", "max", "mean", "std", "p10", "p90"}.
+    """
+    assert cfg.data_sources.forcings is not None, "data_sources.forcings must be set"
+    forcing_store_name = Path(cfg.data_sources.forcings).name
+    statistics_path = Path(cfg.data_sources.statistics)
+    statistics_path.mkdir(exist_ok=True)
+    stats_file = statistics_path / f"{cfg.geodataset.value}_forcing_statistics_{forcing_store_name}.json"
+
+    if stats_file.exists():
+        log.info(f"Reading Forcing Statistics from file: {stats_file.name}")
+        with open(stats_file) as f:
+            loaded: dict[str, dict[str, float]] = json.load(f)
+            return loaded
+
+    log.info(f"Computing forcing statistics for {forcing_store_name}")
+    result: dict[str, dict[str, float]] = {}
+    for var in forcing_var_names:
+        data = ds[var].values  # (divide_id, time)
+        result[var] = {
+            "min": float(np.nanmin(data)),
+            "max": float(np.nanmax(data)),
+            "mean": float(np.nanmean(data)),
+            "std": float(np.nanstd(data)),
+            "p10": float(np.nanpercentile(data, 10)),
+            "p90": float(np.nanpercentile(data, 90)),
+        }
+
+    with open(stats_file, "w") as f:
+        json.dump(result, f, indent=2)
+    log.info(f"Saved forcing statistics to {stats_file.name}")
 
     return result

--- a/src/ddr/io/statistics.py
+++ b/src/ddr/io/statistics.py
@@ -56,3 +56,62 @@ def set_statistics(cfg: Config, ds: xr.Dataset) -> pd.DataFrame:
             json.dump(json_, f, indent=2)
 
     return df
+
+
+def set_streamflow_statistics(cfg: Config, ds: xr.Dataset) -> dict[str, dict[str, float]]:
+    """Compute and cache per-basin mean/std of lateral inflow Q' for z-score normalization.
+
+    Lazily computes statistics on first run, then reads from cached JSON.
+    Statistics are computed over the full time range in the dataset to be
+    stable across train/test splits.
+
+    Parameters
+    ----------
+    cfg : Config
+        Configuration object (uses cfg.data_sources.statistics for cache path
+        and cfg.geodataset for filename prefix).
+    ds : xr.Dataset
+        The streamflow dataset containing 'Qr' variable with dims (time, divide_id).
+
+    Returns
+    -------
+    dict[str, dict[str, float]]
+        Mapping of divide_id (string) -> {"mean": float, "std": float}.
+    """
+    store_name = Path(cfg.data_sources.streamflow).name
+    statistics_path = Path(cfg.data_sources.statistics)
+    statistics_path.mkdir(exist_ok=True)
+    stats_file = statistics_path / f"{cfg.geodataset.value}_streamflow_statistics_{store_name}.json"
+
+    if stats_file.exists():
+        log.info(f"Reading streamflow statistics from file: {stats_file.name}")
+        with open(stats_file) as f:
+            cached: dict[str, dict[str, float]] = json.load(f)
+            return cached
+
+    log.info("Computing per-basin Q' statistics (first run, this may take a few minutes)...")
+    divide_ids = ds.divide_id.values
+    num_divides = len(divide_ids)
+    chunk_size = 1000
+    result: dict[str, dict[str, float]] = {}
+
+    for start in range(0, num_divides, chunk_size):
+        end = min(start + chunk_size, num_divides)
+        chunk = ds["Qr"].isel(divide_id=slice(start, end)).values  # (time, chunk_size)
+        chunk_ids = divide_ids[start:end]
+
+        means = np.nanmean(chunk, axis=0)
+        stds = np.nanstd(chunk, axis=0)
+
+        for i, did in enumerate(chunk_ids):
+            mean_val = float(means[i]) if not np.isnan(means[i]) else 1e-6
+            std_val = float(stds[i]) if not np.isnan(stds[i]) and stds[i] > 0 else 1e-8
+            result[str(did)] = {"mean": mean_val, "std": std_val}
+
+        log.info(f"  Processed {end}/{num_divides} divide_ids")
+
+    with open(stats_file, "w") as f:
+        json.dump(result, f)
+    log.info(f"Saved streamflow statistics to {stats_file.name}")
+
+    return result

--- a/src/ddr/nn/kan.py
+++ b/src/ddr/nn/kan.py
@@ -21,15 +21,12 @@ class kan(torch.nn.Module):
         k: int,
         seed: int,
         device: int | str = "cpu",
-        output_grid_bounds: bool = False,
-        bias_cfg: Any | None = None,
     ):
         super().__init__()
         self.input_size = len(input_var_names)
         self.hidden_size = hidden_size
         self.learnable_parameters = learnable_parameters
         self.output_size = len(self.learnable_parameters)
-        self.output_grid_bounds = output_grid_bounds
 
         self.input = torch.nn.Linear(self.input_size, self.hidden_size, device=device)
         self.layers = torch.nn.ModuleList()
@@ -41,20 +38,10 @@ class kan(torch.nn.Module):
                     grid=grid,
                     seed=seed,
                     device=device,
+                    grid_range=[-4, 4],
                 )
             )
         self.output = torch.nn.Linear(self.hidden_size, self.output_size, bias=True, device=device)
-
-        if output_grid_bounds:
-            bounds_grid = bias_cfg.bounds_grid if bias_cfg else 8
-            bounds_k = bias_cfg.bounds_k if bias_cfg else 3
-            self.bounds_head = KAN(
-                [self.hidden_size, 2],
-                grid=bounds_grid,
-                k=bounds_k,
-                seed=seed,
-                device=device,
-            )
 
         torch.nn.init.kaiming_normal_(self.input.weight, nonlinearity="relu")
         torch.nn.init.xavier_normal_(self.output.weight, gain=0.1)
@@ -75,12 +62,5 @@ class kan(torch.nn.Module):
         x_transpose = _params.transpose(0, 1)
         for idx, key in enumerate(self.learnable_parameters):
             outputs[key] = x_transpose[idx]
-
-        # Grid bounds for φ-KAN normalization
-        if self.output_grid_bounds:
-            bounds_raw = self.bounds_head(_x)
-            bounds = F.softplus(bounds_raw)  # enforce positive
-            grid_bounds = torch.stack([bounds[:, 0], bounds[:, 0] + bounds[:, 1]], dim=1)
-            outputs["grid_bounds"] = grid_bounds
 
         return outputs

--- a/src/ddr/nn/kan.py
+++ b/src/ddr/nn/kan.py
@@ -21,12 +21,15 @@ class kan(torch.nn.Module):
         k: int,
         seed: int,
         device: int | str = "cpu",
+        output_grid_bounds: bool = False,
+        bias_cfg: Any | None = None,
     ):
         super().__init__()
         self.input_size = len(input_var_names)
         self.hidden_size = hidden_size
         self.learnable_parameters = learnable_parameters
         self.output_size = len(self.learnable_parameters)
+        self.output_grid_bounds = output_grid_bounds
 
         self.input = torch.nn.Linear(self.input_size, self.hidden_size, device=device)
         self.layers = torch.nn.ModuleList()
@@ -42,6 +45,17 @@ class kan(torch.nn.Module):
             )
         self.output = torch.nn.Linear(self.hidden_size, self.output_size, bias=True, device=device)
 
+        if output_grid_bounds:
+            bounds_grid = bias_cfg.bounds_grid if bias_cfg else 8
+            bounds_k = bias_cfg.bounds_k if bias_cfg else 3
+            self.bounds_head = KAN(
+                [self.hidden_size, 2],
+                grid=bounds_grid,
+                k=bounds_k,
+                seed=seed,
+                device=device,
+            )
+
         torch.nn.init.kaiming_normal_(self.input.weight, nonlinearity="relu")
         torch.nn.init.xavier_normal_(self.output.weight, gain=0.1)
         torch.nn.init.zeros_(self.input.bias)
@@ -54,9 +68,19 @@ class kan(torch.nn.Module):
         _x = self.input(_x)
         for layer in self.layers:
             _x = layer(_x)
-        _x = self.output(_x)
-        _x = F.sigmoid(_x)
-        x_transpose = _x.transpose(0, 1)
+
+        # Routing parameters
+        _params = self.output(_x)
+        _params = F.sigmoid(_params)
+        x_transpose = _params.transpose(0, 1)
         for idx, key in enumerate(self.learnable_parameters):
             outputs[key] = x_transpose[idx]
+
+        # Grid bounds for φ-KAN normalization
+        if self.output_grid_bounds:
+            bounds_raw = self.bounds_head(_x)
+            bounds = F.softplus(bounds_raw)  # enforce positive
+            grid_bounds = torch.stack([bounds[:, 0], bounds[:, 0] + bounds[:, 1]], dim=1)
+            outputs["grid_bounds"] = grid_bounds
+
         return outputs

--- a/src/ddr/nn/temporal_phi_kan.py
+++ b/src/ddr/nn/temporal_phi_kan.py
@@ -53,6 +53,9 @@ class TemporalPhiKAN(nn.Module):
             seed=seed,
             device=device,
         )
+        self.phi_kan.save_act = False  # avoid in-place ops + save memory
+
+        self.chunk_size = 8192
 
     def forward(
         self,
@@ -112,9 +115,13 @@ class TemporalPhiKAN(nn.Module):
         else:
             raise ValueError(f"Unknown phi_inputs mode: {self.phi_inputs}")
 
-        # Flatten (T, N, input_dim) → (T*N, input_dim), run KAN, reshape back
+        # Flatten (T, N, input_dim) → (T*N, input_dim), run KAN in chunks, reshape back
         phi_input_flat = phi_input.reshape(T * N, self.input_dim)
-        q_corrected_norm = self.phi_kan(phi_input_flat).reshape(T, N)  # (T, N)
+        if T * N > self.chunk_size:
+            chunks = phi_input_flat.split(self.chunk_size, dim=0)
+            q_corrected_norm = torch.cat([self.phi_kan(c) for c in chunks], dim=0).reshape(T, N)
+        else:
+            q_corrected_norm = self.phi_kan(phi_input_flat).reshape(T, N)  # (T, N)
 
         # Denormalize back to physical units
         if grid_bounds is not None:

--- a/src/ddr/nn/temporal_phi_kan.py
+++ b/src/ddr/nn/temporal_phi_kan.py
@@ -1,11 +1,18 @@
 """Temporal φ-KAN for bias correction of lateral inflows.
 
-A small KAN that corrects Q' using flow magnitude and seasonal context.
-By Kolmogorov-Arnold theory, the correction decomposes as:
+A small KAN that learns an additive correction δ to Q' via a residual connection:
 
-  φ(Q', sin_m, cos_m) = Σ_q Φ_q( ψ_{q,Q'}(Q') + ψ_{q,sin}(sin_m) + ψ_{q,cos}(cos_m) )
+  Q'_corrected = Q' + δ(z, ...)      where z = (Q' - μ) / σ  (z-score)
+
+By Kolmogorov-Arnold theory, δ decomposes as:
+
+  δ(z, sin_m, cos_m) = Σ_q Φ_q( ψ_{q,z}(z) + ψ_{q,sin}(sin_m) + ψ_{q,cos}(cos_m) )
 
 Each ψ is a plottable 1D B-spline curve — fully interpretable.
+
+The residual design ensures:
+  - At initialization (KAN ≈ 0), output ≈ Q' (identity pass-through)
+  - After training, the KAN learns only the bias correction, not the full signal
 """
 
 import logging
@@ -124,20 +131,22 @@ class TemporalPhiKAN(nn.Module):
         phi_input_flat = phi_input.reshape(T * N, self.input_dim)
         if T * N > self.chunk_size:
             chunks = phi_input_flat.split(self.chunk_size, dim=0)
-            q_corrected_norm = torch.cat(
+            delta = torch.cat(
                 [checkpoint(self.phi_kan, c, use_reentrant=False) for c in chunks], dim=0
             ).reshape(T, N)
         else:
-            q_corrected_norm = self.phi_kan(phi_input_flat).reshape(T, N)  # (T, N)
+            delta = self.phi_kan(phi_input_flat).reshape(T, N)  # (T, N)
 
         # Clear pykan internal caches that hold autograd graph references
         self.phi_kan.cache_data = None
         self.phi_kan.acts = []
 
-        # Denormalize back to physical units
+        # Residual connection: corrected = original + learned correction
+        # In z-score space: q_corrected_z = q_norm + δ
+        # Denormalized: q_corrected = (q_norm + δ) * σ + μ = q_prime + δ * σ
         if q_prime_mean is not None and q_prime_std is not None:
-            q_corrected = q_corrected_norm * (q_prime_std + 1e-8) + q_prime_mean
+            q_corrected = (q_norm + delta) * (q_prime_std + 1e-8) + q_prime_mean
         else:
-            q_corrected = q_corrected_norm
+            q_corrected = q_prime + delta
 
         return torch.clamp(q_corrected, min=1e-6)

--- a/src/ddr/nn/temporal_phi_kan.py
+++ b/src/ddr/nn/temporal_phi_kan.py
@@ -14,6 +14,7 @@ import math
 import torch
 import torch.nn as nn
 from kan import KAN
+from torch.utils.checkpoint import checkpoint
 
 from ddr.validation.configs import BiasCorrection
 from ddr.validation.enums import PhiInputs
@@ -52,6 +53,7 @@ class TemporalPhiKAN(nn.Module):
             k=cfg.phi_k,
             seed=seed,
             device=device,
+            grid_range=[-4, 4],
         )
         self.phi_kan.save_act = False  # avoid in-place ops + save memory
 
@@ -62,7 +64,8 @@ class TemporalPhiKAN(nn.Module):
         q_prime: torch.Tensor,
         month: torch.Tensor | None = None,
         forcing: torch.Tensor | None = None,
-        grid_bounds: torch.Tensor | None = None,
+        q_prime_mean: torch.Tensor | None = None,
+        q_prime_std: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Bias-correct lateral inflows.
 
@@ -74,8 +77,10 @@ class TemporalPhiKAN(nn.Module):
             Month of year as float [1, 12]. Required for MONTHLY mode.
         forcing : (T, N), optional
             Forcing variable values. Required for FORCING mode.
-        grid_bounds : (N, 2), optional
-            Per-node [min, max] from Spatial KAN for normalization.
+        q_prime_mean : (N,), optional
+            Per-basin mean of Q' from pre-computed statistics.
+        q_prime_std : (N,), optional
+            Per-basin std of Q' from pre-computed statistics.
 
         Returns
         -------
@@ -84,11 +89,9 @@ class TemporalPhiKAN(nn.Module):
         """
         T, N = q_prime.shape
 
-        # Normalize Q' per-node using Spatial KAN's grid bounds
-        if grid_bounds is not None:
-            grid_min = grid_bounds[:, 0]  # (N,)
-            grid_max = grid_bounds[:, 1]  # (N,)
-            q_norm = (q_prime - grid_min) / (grid_max - grid_min + 1e-8)  # (T, N)
+        # Z-score normalize Q' per-node using pre-computed statistics
+        if q_prime_mean is not None and q_prime_std is not None:
+            q_norm = (q_prime - q_prime_mean) / (q_prime_std + 1e-8)  # (T, N)
         else:
             q_norm = q_prime
 
@@ -115,17 +118,25 @@ class TemporalPhiKAN(nn.Module):
         else:
             raise ValueError(f"Unknown phi_inputs mode: {self.phi_inputs}")
 
-        # Flatten (T, N, input_dim) → (T*N, input_dim), run KAN in chunks, reshape back
+        # Flatten (T, N, input_dim) → (T*N, input_dim), run KAN in chunks, reshape back.
+        # Gradient checkpointing trades compute for memory: intermediates are freed
+        # during forward and recomputed during backward (~4 GiB savings).
         phi_input_flat = phi_input.reshape(T * N, self.input_dim)
         if T * N > self.chunk_size:
             chunks = phi_input_flat.split(self.chunk_size, dim=0)
-            q_corrected_norm = torch.cat([self.phi_kan(c) for c in chunks], dim=0).reshape(T, N)
+            q_corrected_norm = torch.cat(
+                [checkpoint(self.phi_kan, c, use_reentrant=False) for c in chunks], dim=0
+            ).reshape(T, N)
         else:
             q_corrected_norm = self.phi_kan(phi_input_flat).reshape(T, N)  # (T, N)
 
+        # Clear pykan internal caches that hold autograd graph references
+        self.phi_kan.cache_data = None
+        self.phi_kan.acts = []
+
         # Denormalize back to physical units
-        if grid_bounds is not None:
-            q_corrected = q_corrected_norm * (grid_max - grid_min) + grid_min
+        if q_prime_mean is not None and q_prime_std is not None:
+            q_corrected = q_corrected_norm * (q_prime_std + 1e-8) + q_prime_mean
         else:
             q_corrected = q_corrected_norm
 

--- a/src/ddr/routing/mmc.py
+++ b/src/ddr/routing/mmc.py
@@ -373,15 +373,17 @@ class MuskingumCunge:
                 dtype=torch.float32,
             )
 
-            # Vectorized initial values
+            # Vectorized initial values — compute clamp on standalone tensor
+            # to avoid read-modify-write on output (breaks autograd when
+            # discharge requires grad, e.g. via TemporalPhiKAN)
             gathered = self._discharge_t[self._flat_indices]
-            output[:, 0] = torch.scatter_add(
+            initial = torch.scatter_add(
                 input=self._scatter_input,
                 dim=0,
                 index=self._group_ids,
                 src=gathered,
             )
-            output[:, 0] = torch.clamp(output[:, 0], min=self.discharge_lb)
+            output[:, 0] = torch.clamp(initial, min=self.discharge_lb)
 
         # Route through time series
         for timestep in tqdm(

--- a/src/ddr/scripts_utils.py
+++ b/src/ddr/scripts_utils.py
@@ -70,8 +70,8 @@ def load_checkpoint(
     log.info(f"Loading spatial_nn from checkpoint: {file_path.stem}")
     state: dict = torch.load(file_path, map_location=device)
     state_dict = state["model_state_dict"]
-    for key in state_dict.keys():
-        state_dict[key] = state_dict[key].to(device)
+    # Filter out bounds_head keys from old checkpoints (bounds_head was removed)
+    state_dict = {k: v.to(device) for k, v in state_dict.items() if not k.startswith("bounds_head")}
     nn.load_state_dict(state_dict)
 
     if phi_kan is not None and "phi_kan_state_dict" in state:

--- a/src/ddr/scripts_utils.py
+++ b/src/ddr/scripts_utils.py
@@ -46,6 +46,7 @@ def load_checkpoint(
     nn: torch.nn.Module,
     checkpoint_path: str | Path,
     device: str | torch.device,
+    phi_kan: torch.nn.Module | None = None,
 ) -> dict:
     """Load DDR checkpoint, apply state_dict to model. Returns full state dict.
 
@@ -57,6 +58,8 @@ def load_checkpoint(
         Path to the .pt checkpoint file.
     device : str | torch.device
         Device to map tensors to.
+    phi_kan : torch.nn.Module | None
+        Optional phi-KAN module to load weights into.
 
     Returns
     -------
@@ -70,6 +73,16 @@ def load_checkpoint(
     for key in state_dict.keys():
         state_dict[key] = state_dict[key].to(device)
     nn.load_state_dict(state_dict)
+
+    if phi_kan is not None and "phi_kan_state_dict" in state:
+        phi_state = state["phi_kan_state_dict"]
+        for key in phi_state:
+            phi_state[key] = phi_state[key].to(device)
+        phi_kan.load_state_dict(phi_state)
+        log.info("Loaded phi_kan weights from checkpoint")
+    elif phi_kan is not None:
+        log.warning("No phi_kan_state_dict in checkpoint, using random init")
+
     return state
 
 

--- a/src/ddr/validation/configs.py
+++ b/src/ddr/validation/configs.py
@@ -206,7 +206,10 @@ class BiasCorrection(BaseModel):
         default=None,
         description="Forcing variable name (required when phi_inputs='forcing')",
     )
-    phi_hidden_size: int = Field(default=5, description="Hidden layer size for the phi-KAN")
+    phi_hidden_size: int | None = Field(
+        default=None,
+        description="Hidden layer size for the phi-KAN. Defaults to 2n+1 (Kolmogorov-Arnold theorem minimum) based on phi_inputs mode.",
+    )
     phi_grid: int = Field(default=8, description="Grid size for phi-KAN B-spline basis")
     phi_k: int = Field(default=3, description="B-spline order for phi-KAN layers")
     lambda_mass: float = Field(
@@ -223,10 +226,20 @@ class BiasCorrection(BaseModel):
     )
 
     @model_validator(mode="after")
-    def validate_forcing_var(self) -> "BiasCorrection":
-        """Validate that forcing_var is set when phi_inputs is 'forcing'"""
+    def validate_and_resolve(self) -> "BiasCorrection":
+        """Validate forcing_var and auto-size phi_hidden_size from 2n+1."""
         if self.phi_inputs == PhiInputs.FORCING and self.forcing_var is None:
             raise ValueError("forcing_var must be set when phi_inputs='forcing'")
+
+        if self.phi_hidden_size is None:
+            input_dims = {
+                PhiInputs.STATIC: 1,
+                PhiInputs.MONTHLY: 3,
+                PhiInputs.FORCING: 2,
+                PhiInputs.RANDOM: 3,
+            }
+            n = input_dims[self.phi_inputs]
+            self.phi_hidden_size = 2 * n + 1
         return self
 
 

--- a/src/ddr/validation/configs.py
+++ b/src/ddr/validation/configs.py
@@ -9,7 +9,7 @@ from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig, OmegaConf
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
-from ddr.validation.enums import GeoDataset, Mode, PhiInputs
+from ddr.validation.enums import BiasLossFn, GeoDataset, Mode, PhiInputs
 
 log = logging.getLogger(__name__)
 
@@ -213,12 +213,10 @@ class BiasCorrection(BaseModel):
         default=False,
         description="Whether to anneal lambda_mass over training epochs",
     )
-    use_kge_loss: bool = Field(
-        default=True,
-        description="Whether to use KGE loss (True) or MSE loss (False) when bias is enabled",
+    loss_fn: BiasLossFn = Field(
+        default=BiasLossFn.HUBER,
+        description="Loss function for bias correction training: 'huber', 'kge', or 'mse'",
     )
-    bounds_grid: int = Field(default=8, description="Grid size for bounds head KAN B-spline basis")
-    bounds_k: int = Field(default=3, description="B-spline order for bounds head KAN layers")
 
     @model_validator(mode="after")
     def validate_forcing_var(self) -> "BiasCorrection":

--- a/src/ddr/validation/configs.py
+++ b/src/ddr/validation/configs.py
@@ -217,6 +217,8 @@ class BiasCorrection(BaseModel):
         default=True,
         description="Whether to use KGE loss (True) or MSE loss (False) when bias is enabled",
     )
+    bounds_grid: int = Field(default=8, description="Grid size for bounds head KAN B-spline basis")
+    bounds_k: int = Field(default=3, description="B-spline order for bounds head KAN layers")
 
     @model_validator(mode="after")
     def validate_forcing_var(self) -> "BiasCorrection":

--- a/src/ddr/validation/configs.py
+++ b/src/ddr/validation/configs.py
@@ -71,6 +71,10 @@ class DataSources(BaseModel):
     target_catchments: list[str] | None = Field(
         default=None, description="Optional list of specific catchment IDs to route to (overrides gages)"
     )
+    forcings: str | None = Field(
+        default=None,
+        description="Path to icechunk store with meteorological forcings (P, PET, Temp)",
+    )
 
 
 class Params(BaseModel):

--- a/src/ddr/validation/enums.py
+++ b/src/ddr/validation/enums.py
@@ -23,6 +23,14 @@ class PhiInputs(StrEnum):
     RANDOM = "random"
 
 
+class BiasLossFn(StrEnum):
+    """Loss function for bias correction training"""
+
+    HUBER = "huber"
+    KGE = "kge"
+    MSE = "mse"
+
+
 class GeoDataset(StrEnum):
     """The geospatial dataset used for predictions and routing"""
 

--- a/src/ddr/validation/losses.py
+++ b/src/ddr/validation/losses.py
@@ -11,12 +11,16 @@ import torch
 def mass_balance_loss(
     q_corrected: torch.Tensor,
     target: torch.Tensor,
-    eps: float = 1e-6,
 ) -> torch.Tensor:
-    """Mass balance (ρ) loss — gives φ direct gradients bypassing MC.
+    """Mass balance loss — MAE between predicted and observed total volumes.
 
-    MC conserves mass, so total volume at gauge equals total injected volume
-    upstream. ρ_g = AUC_pred_g / AUC_obs_g. Loss = mean((ρ - 1)²).
+    Gives φ-KAN direct gradients bypassing MC routing. MC conserves mass,
+    so total volume at gauge equals total injected volume upstream.
+
+    Loss = mean_over_gauges(|sum(pred) - sum(obs)|)
+
+    This is in the same units as the prediction (m³/s·timesteps), so it
+    naturally competes at a similar magnitude to pointwise losses like Huber.
 
     Parameters
     ----------
@@ -24,8 +28,6 @@ def mass_balance_loss(
         Bias-corrected discharge at gauge locations.
     target : (G, T)
         Observed discharge at gauge locations.
-    eps : float
-        Small constant to prevent division by zero.
 
     Returns
     -------
@@ -33,8 +35,7 @@ def mass_balance_loss(
     """
     auc_pred = q_corrected.sum(dim=1)  # (G,)
     auc_obs = target.sum(dim=1)  # (G,)
-    rho = auc_pred / (auc_obs + eps)
-    return ((rho - 1.0) ** 2).mean()
+    return (auc_pred - auc_obs).abs().mean()
 
 
 def kge_loss(

--- a/src/ddr/validation/losses.py
+++ b/src/ddr/validation/losses.py
@@ -2,6 +2,7 @@
 
 mass_balance_loss: gives φ-KAN direct gradients (bypasses MC routing).
 kge_loss: Kling-Gupta Efficiency loss that flows through MC routing.
+huber_loss: robust regression loss (quadratic near zero, linear for outliers).
 """
 
 import torch
@@ -82,3 +83,30 @@ def kge_loss(
     # Euclidean distance from ideal (1, 1, 1)
     ed = torch.sqrt((r - 1) ** 2 + (alpha - 1) ** 2 + (beta - 1) ** 2 + eps)  # (G,)
     return ed.mean()
+
+
+def huber_loss(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    delta: float = 1.0,
+) -> torch.Tensor:
+    """Huber loss averaged across gauges and time.
+
+    Quadratic for errors < delta, linear for errors >= delta.
+    Provides stronger raw-magnitude gradients than KGE while being
+    robust to outlier flood events.
+
+    Parameters
+    ----------
+    pred : (G, T)
+        Predicted discharge at gauge locations.
+    target : (G, T)
+        Observed discharge at gauge locations.
+    delta : float
+        Threshold where loss transitions from quadratic to linear.
+
+    Returns
+    -------
+    loss : scalar tensor
+    """
+    return torch.nn.functional.huber_loss(pred, target, delta=delta)

--- a/src/ddr/validation/utils.py
+++ b/src/ddr/validation/utils.py
@@ -17,6 +17,7 @@ def save_state(
     optimizer: nn.Module,
     name: str,
     saved_model_path: Path,
+    phi_kan: nn.Module | None = None,
 ) -> None:
     """Save model state
 
@@ -65,6 +66,9 @@ def save_state(
     }
     if torch.cuda.is_available():
         state["cuda_rng_state"] = torch.cuda.get_rng_state()
+    if phi_kan is not None:
+        state["phi_kan_state_dict"] = {k: v.cpu() for k, v in phi_kan.state_dict().items()}
+
     if mini_batch == -1:
         state["epoch"] = epoch + 1
         state["mini_batch"] = 0

--- a/tests/nn/test_temporal_phi_kan.py
+++ b/tests/nn/test_temporal_phi_kan.py
@@ -90,22 +90,23 @@ class TestTemporalPhiKAN:
 
         assert torch.equal(out1, out2)
 
-    def test_with_grid_bounds(self) -> None:
+    def test_with_q_prime_stats(self) -> None:
         model = self._make_phi_kan(PhiInputs.MONTHLY)
         T, N = 12, 5
         q_prime = torch.rand(T, N) * 100
         month = torch.full((T,), 6.0)
-        grid_bounds = torch.tensor([[0.0, 100.0]] * N)
+        q_prime_mean = torch.full((N,), 50.0)
+        q_prime_std = torch.full((N,), 25.0)
 
-        output = model(q_prime, month=month, grid_bounds=grid_bounds)
+        output = model(q_prime, month=month, q_prime_mean=q_prime_mean, q_prime_std=q_prime_std)
         assert output.shape == (T, N)
 
-    def test_without_grid_bounds(self) -> None:
+    def test_without_q_prime_stats(self) -> None:
         model = self._make_phi_kan(PhiInputs.STATIC)
         T, N = 12, 5
         q_prime = torch.rand(T, N)
 
-        output = model(q_prime, grid_bounds=None)
+        output = model(q_prime, q_prime_mean=None, q_prime_std=None)
         assert output.shape == (T, N)
 
     def test_monotonicity(self) -> None:

--- a/tests/routing/test_bias_correction_integration.py
+++ b/tests/routing/test_bias_correction_integration.py
@@ -1,0 +1,194 @@
+"""Integration tests for φ-KAN bias correction pipeline."""
+
+import torch
+
+from ddr.nn.kan import kan
+from ddr.nn.temporal_phi_kan import TemporalPhiKAN
+from ddr.validation.configs import BiasCorrection
+from ddr.validation.enums import PhiInputs
+from ddr.validation.losses import kge_loss, mass_balance_loss
+
+
+class TestEndToEndSynthetic:
+    """End-to-end synthetic data through φ-KAN."""
+
+    def test_output_shape_and_non_negative(self) -> None:
+        cfg = BiasCorrection(phi_inputs=PhiInputs.MONTHLY)
+        phi_kan = TemporalPhiKAN(cfg=cfg, seed=42, device="cpu")
+        T, N = 48, 10
+        q_prime = torch.rand(T, N)
+        month = torch.full((T,), 6.0)
+        output = phi_kan(q_prime, month=month)
+
+        assert output.shape == (T, N)
+        assert (output >= 1e-6).all(), "Output should be non-negative"
+
+    def test_with_grid_bounds_from_spatial_kan(self) -> None:
+        """Full pipeline: Spatial KAN → grid_bounds → φ-KAN."""
+        bias_cfg = BiasCorrection(phi_inputs=PhiInputs.STATIC)
+        spatial_kan = kan(
+            input_var_names=["attr1", "attr2", "attr3"],
+            learnable_parameters=["n", "q_spatial"],
+            hidden_size=7,
+            num_hidden_layers=1,
+            grid=3,
+            k=3,
+            seed=42,
+            device="cpu",
+            output_grid_bounds=True,
+            bias_cfg=bias_cfg,
+        )
+        phi_kan = TemporalPhiKAN(cfg=bias_cfg, seed=42, device="cpu")
+
+        N = 5
+        inputs = torch.rand(N, 3)
+        spatial_params = spatial_kan(inputs=inputs)
+
+        assert "grid_bounds" in spatial_params
+        grid_bounds = spatial_params.pop("grid_bounds")
+        assert grid_bounds.shape == (N, 2)
+        assert (grid_bounds[:, 1] > grid_bounds[:, 0]).all(), "max should be > min"
+
+        T = 24
+        q_prime = torch.rand(T, N)
+        output = phi_kan(q_prime, grid_bounds=grid_bounds)
+        assert output.shape == (T, N)
+
+
+class TestGradientFlow:
+    """Verify gradients flow correctly through the combined loss."""
+
+    def test_combined_loss_grads_reach_both_networks(self) -> None:
+        """Both φ-KAN and Spatial KAN should receive gradients from combined loss."""
+        bias_cfg = BiasCorrection(phi_inputs=PhiInputs.STATIC)
+        spatial_kan = kan(
+            input_var_names=["a", "b", "c"],
+            learnable_parameters=["n", "q_spatial"],
+            hidden_size=7,
+            num_hidden_layers=1,
+            grid=3,
+            k=3,
+            seed=42,
+            device="cpu",
+            output_grid_bounds=True,
+            bias_cfg=bias_cfg,
+        )
+        phi_kan = TemporalPhiKAN(cfg=bias_cfg, seed=42, device="cpu")
+
+        N = 5
+        inputs = torch.rand(N, 3)
+        spatial_params = spatial_kan(inputs=inputs)
+        grid_bounds = spatial_params.pop("grid_bounds")
+
+        T = 12
+        q_prime = torch.rand(T, N, requires_grad=True)
+        q_corrected = phi_kan(q_prime, grid_bounds=grid_bounds)
+
+        # Simulate MC routing as a simple linear transform (preserves gradient flow)
+        mc_layer = torch.nn.Linear(N, N, bias=False)
+        q_routed = mc_layer(q_corrected)
+
+        target = torch.rand(T, N)
+
+        # Combined loss
+        mb = mass_balance_loss(q_corrected, target)
+        kge = kge_loss(q_routed, target)
+        loss = 0.5 * mb + 0.5 * kge
+        loss.backward()
+
+        # φ-KAN should have gradients (from both losses)
+        phi_has_grad = any(p.grad is not None and p.grad.abs().sum() > 0 for p in phi_kan.parameters())
+        assert phi_has_grad, "φ-KAN should receive gradients from combined loss"
+
+        # Spatial KAN should have gradients (from kge_loss through MC)
+        spatial_has_grad = any(
+            p.grad is not None and p.grad.abs().sum() > 0 for p in spatial_kan.parameters()
+        )
+        assert spatial_has_grad, "Spatial KAN should receive gradients from kge_loss"
+
+    def test_mass_balance_does_not_grad_mc(self) -> None:
+        """mass_balance_loss on pre-MC output must not send gradients to MC."""
+        mc_layer = torch.nn.Linear(5, 5, bias=False)
+        q_corrected = torch.rand(12, 5, requires_grad=True)
+        target = torch.rand(12, 5)
+
+        # MC processes q_corrected but loss is computed on pre-MC values
+        _q_routed = mc_layer(q_corrected)
+        loss = mass_balance_loss(q_corrected, target)
+        loss.backward()
+
+        assert mc_layer.weight.grad is None, "MC should not receive gradients from mass_balance_loss"
+        assert q_corrected.grad is not None, "q_corrected should receive gradients"
+
+    def test_kge_loss_grads_reach_both(self) -> None:
+        """kge_loss through MC should reach both φ-KAN and MC params."""
+        bias_cfg = BiasCorrection(phi_inputs=PhiInputs.STATIC)
+        phi_kan = TemporalPhiKAN(cfg=bias_cfg, seed=42, device="cpu")
+
+        T, N = 12, 5
+        q_prime = torch.rand(T, N, requires_grad=True)
+        q_corrected = phi_kan(q_prime)
+
+        mc_layer = torch.nn.Linear(N, N, bias=False)
+        q_routed = mc_layer(q_corrected)
+
+        target = torch.rand(T, N)
+        loss = kge_loss(q_routed, target)
+        loss.backward()
+
+        phi_has_grad = any(p.grad is not None and p.grad.abs().sum() > 0 for p in phi_kan.parameters())
+        mc_has_grad = mc_layer.weight.grad is not None and mc_layer.weight.grad.abs().sum() > 0
+        assert phi_has_grad, "φ-KAN should receive gradients through MC from kge_loss"
+        assert mc_has_grad, "MC should receive gradients from kge_loss"
+
+
+class TestBackwardCompatibility:
+    """Verify bias disabled preserves existing behavior."""
+
+    def test_kan_without_bounds_unchanged(self) -> None:
+        """kan with output_grid_bounds=False should behave identically to before."""
+        nn = kan(
+            input_var_names=["a", "b", "c"],
+            learnable_parameters=["n", "q_spatial"],
+            hidden_size=7,
+            num_hidden_layers=1,
+            grid=3,
+            k=3,
+            seed=42,
+            device="cpu",
+        )
+        N = 5
+        inputs = torch.rand(N, 3)
+        outputs = nn(inputs=inputs)
+
+        assert "n" in outputs
+        assert "q_spatial" in outputs
+        assert "grid_bounds" not in outputs
+        assert outputs["n"].shape == (N,)
+        assert outputs["q_spatial"].shape == (N,)
+
+    def test_kan_with_bounds_still_produces_routing_params(self) -> None:
+        """With bounds enabled, routing params should still be present and valid."""
+        bias_cfg = BiasCorrection()
+        nn = kan(
+            input_var_names=["a", "b", "c"],
+            learnable_parameters=["n", "q_spatial"],
+            hidden_size=7,
+            num_hidden_layers=1,
+            grid=3,
+            k=3,
+            seed=42,
+            device="cpu",
+            output_grid_bounds=True,
+            bias_cfg=bias_cfg,
+        )
+        N = 5
+        inputs = torch.rand(N, 3)
+        outputs = nn(inputs=inputs)
+
+        assert "n" in outputs
+        assert "q_spatial" in outputs
+        assert "grid_bounds" in outputs
+        # Routing params should still be in [0, 1] (sigmoid)
+        assert (outputs["n"] >= 0).all() and (outputs["n"] <= 1).all()
+        assert (outputs["q_spatial"] >= 0).all() and (outputs["q_spatial"] <= 1).all()

--- a/tests/routing/test_bias_correction_integration.py
+++ b/tests/routing/test_bias_correction_integration.py
@@ -6,7 +6,7 @@ from ddr.nn.kan import kan
 from ddr.nn.temporal_phi_kan import TemporalPhiKAN
 from ddr.validation.configs import BiasCorrection
 from ddr.validation.enums import PhiInputs
-from ddr.validation.losses import kge_loss, mass_balance_loss
+from ddr.validation.losses import huber_loss, kge_loss, mass_balance_loss
 
 
 class TestEndToEndSynthetic:
@@ -23,35 +23,17 @@ class TestEndToEndSynthetic:
         assert output.shape == (T, N)
         assert (output >= 1e-6).all(), "Output should be non-negative"
 
-    def test_with_grid_bounds_from_spatial_kan(self) -> None:
-        """Full pipeline: Spatial KAN → grid_bounds → φ-KAN."""
+    def test_with_precomputed_q_prime_stats(self) -> None:
+        """φ-KAN with pre-computed per-basin mean/std for z-score normalization."""
         bias_cfg = BiasCorrection(phi_inputs=PhiInputs.STATIC)
-        spatial_kan = kan(
-            input_var_names=["attr1", "attr2", "attr3"],
-            learnable_parameters=["n", "q_spatial"],
-            hidden_size=7,
-            num_hidden_layers=1,
-            grid=3,
-            k=3,
-            seed=42,
-            device="cpu",
-            output_grid_bounds=True,
-            bias_cfg=bias_cfg,
-        )
         phi_kan = TemporalPhiKAN(cfg=bias_cfg, seed=42, device="cpu")
 
-        N = 5
-        inputs = torch.rand(N, 3)
-        spatial_params = spatial_kan(inputs=inputs)
+        T, N = 24, 5
+        q_prime = torch.rand(T, N) * 100
+        q_prime_mean = torch.full((N,), 50.0)
+        q_prime_std = torch.full((N,), 25.0)
 
-        assert "grid_bounds" in spatial_params
-        grid_bounds = spatial_params.pop("grid_bounds")
-        assert grid_bounds.shape == (N, 2)
-        assert (grid_bounds[:, 1] > grid_bounds[:, 0]).all(), "max should be > min"
-
-        T = 24
-        q_prime = torch.rand(T, N)
-        output = phi_kan(q_prime, grid_bounds=grid_bounds)
+        output = phi_kan(q_prime, q_prime_mean=q_prime_mean, q_prime_std=q_prime_std)
         assert output.shape == (T, N)
 
 
@@ -59,7 +41,11 @@ class TestGradientFlow:
     """Verify gradients flow correctly through the combined loss."""
 
     def test_combined_loss_grads_reach_both_networks(self) -> None:
-        """Both φ-KAN and Spatial KAN should receive gradients from combined loss."""
+        """Both φ-KAN and Spatial KAN should receive gradients from combined loss.
+
+        Spatial KAN receives gradients through routing params used in MC routing,
+        not through the φ-KAN normalization (which now uses pre-computed stats).
+        """
         bias_cfg = BiasCorrection(phi_inputs=PhiInputs.STATIC)
         spatial_kan = kan(
             input_var_names=["a", "b", "c"],
@@ -70,41 +56,41 @@ class TestGradientFlow:
             k=3,
             seed=42,
             device="cpu",
-            output_grid_bounds=True,
-            bias_cfg=bias_cfg,
         )
         phi_kan = TemporalPhiKAN(cfg=bias_cfg, seed=42, device="cpu")
 
         N = 5
         inputs = torch.rand(N, 3)
         spatial_params = spatial_kan(inputs=inputs)
-        grid_bounds = spatial_params.pop("grid_bounds")
 
         T = 12
         q_prime = torch.rand(T, N, requires_grad=True)
-        q_corrected = phi_kan(q_prime, grid_bounds=grid_bounds)
+        q_prime_mean = torch.full((N,), 0.5)
+        q_prime_std = torch.full((N,), 0.3)
+        q_corrected = phi_kan(q_prime, q_prime_mean=q_prime_mean, q_prime_std=q_prime_std)
 
-        # Simulate MC routing as a simple linear transform (preserves gradient flow)
-        mc_layer = torch.nn.Linear(N, N, bias=False)
-        q_routed = mc_layer(q_corrected)
+        # Simulate MC routing using spatial params (n) as a scaling factor
+        # This creates the gradient path: spatial_kan → routing_params → MC → loss
+        n_param = spatial_params["n"].unsqueeze(0).expand(T, N)
+        q_routed = q_corrected * n_param  # simplified MC: scale by learned parameter
 
         target = torch.rand(T, N)
 
         # Combined loss
         mb = mass_balance_loss(q_corrected, target)
-        kge = kge_loss(q_routed, target)
-        loss = 0.5 * mb + 0.5 * kge
+        huber = huber_loss(q_routed, target)
+        loss = 0.5 * mb + 0.5 * huber
         loss.backward()
 
         # φ-KAN should have gradients (from both losses)
         phi_has_grad = any(p.grad is not None and p.grad.abs().sum() > 0 for p in phi_kan.parameters())
         assert phi_has_grad, "φ-KAN should receive gradients from combined loss"
 
-        # Spatial KAN should have gradients (from kge_loss through MC)
+        # Spatial KAN should have gradients (from huber_loss through MC routing params)
         spatial_has_grad = any(
             p.grad is not None and p.grad.abs().sum() > 0 for p in spatial_kan.parameters()
         )
-        assert spatial_has_grad, "Spatial KAN should receive gradients from kge_loss"
+        assert spatial_has_grad, "Spatial KAN should receive gradients through routing params"
 
     def test_mass_balance_does_not_grad_mc(self) -> None:
         """mass_balance_loss on pre-MC output must not send gradients to MC."""
@@ -145,8 +131,8 @@ class TestGradientFlow:
 class TestBackwardCompatibility:
     """Verify bias disabled preserves existing behavior."""
 
-    def test_kan_without_bounds_unchanged(self) -> None:
-        """kan with output_grid_bounds=False should behave identically to before."""
+    def test_kan_produces_routing_params(self) -> None:
+        """kan should produce routing params without any bias-related outputs."""
         nn = kan(
             input_var_names=["a", "b", "c"],
             learnable_parameters=["n", "q_spatial"],
@@ -166,29 +152,6 @@ class TestBackwardCompatibility:
         assert "grid_bounds" not in outputs
         assert outputs["n"].shape == (N,)
         assert outputs["q_spatial"].shape == (N,)
-
-    def test_kan_with_bounds_still_produces_routing_params(self) -> None:
-        """With bounds enabled, routing params should still be present and valid."""
-        bias_cfg = BiasCorrection()
-        nn = kan(
-            input_var_names=["a", "b", "c"],
-            learnable_parameters=["n", "q_spatial"],
-            hidden_size=7,
-            num_hidden_layers=1,
-            grid=3,
-            k=3,
-            seed=42,
-            device="cpu",
-            output_grid_bounds=True,
-            bias_cfg=bias_cfg,
-        )
-        N = 5
-        inputs = torch.rand(N, 3)
-        outputs = nn(inputs=inputs)
-
-        assert "n" in outputs
-        assert "q_spatial" in outputs
-        assert "grid_bounds" in outputs
         # Routing params should still be in [0, 1] (sigmoid)
         assert (outputs["n"] >= 0).all() and (outputs["n"] <= 1).all()
         assert (outputs["q_spatial"] >= 0).all() and (outputs["q_spatial"] <= 1).all()


### PR DESCRIPTION
## Summary
- Implement new temporal phi KAN with Qprime input at the daily scale
- Add forcing readers and date range support for data loading
- Add normalization values and remove in-place operations for training stability
- Upgrade loss functions with additional validation utilities
- Add bias correction integration tests

## Changes
- **`scripts/train.py` / `scripts/train_and_test.py`**: Extended training and evaluation pipelines for the new KAN architecture
- **`src/ddr/nn/temporal_phi_kan.py`**: Refactored temporal phi KAN with Qprime daily-scale input
- **`src/ddr/io/readers.py` / `src/ddr/io/statistics.py`**: New forcing data readers and statistics computation
- **`src/ddr/validation/losses.py`**: Upgraded loss functions
- **`src/ddr/validation/configs.py` / `enums.py` / `utils.py`**: Extended configs and validation enums
- **`src/ddr/geodatazoo/dataclasses.py`**: Additional dataclass fields
- **`src/ddr/routing/mmc.py`**: Minor routing adjustments
- **`tests/`**: Updated KAN tests and added bias correction integration tests

## Test plan
- [ ] Run existing unit tests (`tests/nn/test_temporal_phi_kan.py`)
- [ ] Run new integration tests (`tests/routing/test_bias_correction_integration.py`)
- [ ] Verify training script runs end-to-end with updated config

🤖 Generated with [Claude Code](https://claude.com/claude-code)